### PR TITLE
Make styling consistent with default Omarchy Waybar

### DIFF
--- a/config/waybar/hyprwhspr-style.css
+++ b/config/waybar/hyprwhspr-style.css
@@ -3,8 +3,9 @@
 /* Base styles - same icon for all states, only colors change */
 #custom-hyprwhspr {
   margin: 0 16px;
-  font-size: 16px;
+  font-size: 12px;
   font-weight: bold;
+  border-top: 2px solid transparent;
   border-bottom: 2px solid transparent;
   transition: color 150ms ease-in-out, border-color 150ms ease-in-out;
 }
@@ -16,12 +17,12 @@
 
 #custom-hyprwhspr.recording {
   color: #dc2626;            /* red-600 - darker red for better contrast */
-  border-color: #dc2626;
+  border-bottom-color: #dc2626;
 }
 
 #custom-hyprwhspr.error {
   color: #d97706;            /* amber-600 - original perfect color */
-  border-color: #d97706;
+  border-bottom-color: #d97706;
 }
 
 /* Hover effects - Waybar doesn't support filter, so we use opacity instead */


### PR DESCRIPTION
The current styling of the waybar icon is larger than the other icons in the default Omarchy setup and above centre vertically:
<img width="211" height="30" alt="image" src="https://github.com/user-attachments/assets/3667aa43-fda6-4b7a-ac82-506fe6930c9b" />

This change reduces the size of the icon for consistency and adds a top 2px border to match the bottom, to centre vertically:
<img width="219" height="30" alt="image" src="https://github.com/user-attachments/assets/753e6388-c1c5-4ba1-ae22-c99b44373061" />
