### PR TITLE
Use ctrlshift as default not super

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,15 +244,15 @@ _Speech-to-text replacement list via [WhisperTux](https://github.com/cjams/whisp
 
 ```jsonc
 {
-    "paste_mode": "super"   // "super" | "ctrl_shift" | "ctrl"  (default: "super")
+    "paste_mode": "ctrl_shift"   // "super" | "ctrl_shift" | "ctrl"  (default: "ctrl_shift")
 }
 ```
 
 **Paste behavior options:**
 
-- **`"super"`** (default) — Sends Super+V. Omarchy default.
+- **`"ctrl_shift"`** (default) — Sends Ctrl+Shift+V. Works in most terminals.
 
-- **`"ctrl_shift"`** — Sends Ctrl+Shift+V. Works in most terminals.
+- **`"super"`** — Sends Super+V. Omarchy default. Maybe finicky.
 
 - **`"ctrl"`** — Sends Ctrl+V. Standard GUI paste.
 

--- a/lib/src/config_manager.py
+++ b/lib/src/config_manager.py
@@ -23,8 +23,8 @@ class ConfigManager:
             'clipboard_behavior': False,  # Boolean: true = clear clipboard after delay, false = keep (current behavior)
             'clipboard_clear_delay': 5.0,  # Float: seconds to wait before clearing clipboard (only used if clipboard_behavior is true)
             # Values: "super" | "ctrl_shift" | "ctrl"
-            # Default "super" aligns with Omarchy global paste via Super+V.
-            'paste_mode': 'super',
+            # Default "ctrl_shift" for flexible unix-y primitive
+            'paste_mode': 'ctrl_shift',
             # Back-compat for older configs (used only if paste_mode is absent):
             'shift_paste': True,  # true = Ctrl+Shift+V, false = Ctrl+V
             # Transcription backend settings


### PR DESCRIPTION
A user reported issues with the super default and I'm a little worried that it might cause conflicts. Using shift as default feels a little safer, and then optionally folks can use super if they wish. 