### PR TITLE
feat(shortcuts): Allow single modifier keys as hotkeys

### DIFF
--- a/lib/src/global_shortcuts.py
+++ b/lib/src/global_shortcuts.py
@@ -299,7 +299,7 @@ class GlobalShortcuts:
     
     def _check_shortcut_combination(self):
         """Check if current pressed keys match target combination"""
-        if self.target_keys.issubset(self.pressed_keys):
+        if self.target_keys == self.pressed_keys:
             current_time = time.time()
             
             # Implement debouncing


### PR DESCRIPTION
The previous implementation of the shortcut detection used `issubset` to check for the pressed keys. This caused issues when using a single modifier key (e.g., `rmeta`) as a hotkey, as it would trigger even when other keys were pressed simultaneously.

This commit changes the check to an exact match (`==`), ensuring that the shortcut is only triggered when the *exact* combination of keys is pressed. This allows for the use of single modifier keys as hotkeys and makes the shortcut detection more robust and predictable.