### PR TITLE
fix: wait for Wayland environment before starting service

### DIFF
--- a/config/systemd/hyprwhspr.service
+++ b/config/systemd/hyprwhspr.service
@@ -7,7 +7,8 @@ Wants=pipewire.service
 
 [Service]
 Type=simple
-ExecStartPre=/bin/sleep 3
+# Wait for Wayland environment - wl-copy needs WAYLAND_DISPLAY to be set
+ExecStartPre=/bin/bash -c 'for i in $(seq 1 30); do [ -n "$WAYLAND_DISPLAY" ] && exit 0; sleep 0.5; done; echo "Warning: WAYLAND_DISPLAY not set after 15s"'
 ExecStart=/usr/lib/hyprwhspr/bin/hyprwhspr
 Environment=HYPRWHSPR_ROOT=/usr/lib/hyprwhspr
 Restart=on-failure


### PR DESCRIPTION
## Problem

The hyprwhspr service can start before `WAYLAND_DISPLAY` is set in the systemd user environment. When this happens, `wl-copy` fails with exit code 1 because it cannot connect to the Wayland compositor:

```
Clipboard+hotkey injection failed: Command '['wl-copy']' returned non-zero exit status 1.
```

Text injection silently fails even though transcription completes successfully.

## Solution

Replace the fixed 3-second sleep with a loop that waits for `WAYLAND_DISPLAY` to be set (up to 15 seconds). This is more robust than a fixed delay because:

1. It exits immediately once the environment is ready (faster startup when possible)
2. It handles systems where the graphical session takes longer to initialize
3. It provides a warning if the environment never becomes available

## Testing

Tested on Arch Linux with Hyprland. After this fix, restarting the service is no longer required after login - text injection works reliably on first use.