### PR TITLE
Fix Wayland detection to use socket file instead of env var

### DIFF
--- a/config/systemd/hyprwhspr.service
+++ b/config/systemd/hyprwhspr.service
@@ -7,8 +7,9 @@ Wants=pipewire.service
 
 [Service]
 Type=simple
-# Wait for Wayland environment - wl-copy needs WAYLAND_DISPLAY to be set
-ExecStartPre=/bin/bash -c 'for i in $(seq 1 30); do [ -n "$WAYLAND_DISPLAY" ] && exit 0; sleep 0.5; done; echo "Warning: WAYLAND_DISPLAY not set after 15s"'
+# Wait for Wayland compositor - check for socket file directly since systemd
+# services don't inherit WAYLAND_DISPLAY from the graphical session
+ExecStartPre=/bin/bash -c 'for i in $(seq 1 30); do ls /run/user/$(id -u)/wayland-* >/dev/null 2>&1 && exit 0; sleep 0.5; done; echo "Warning: Wayland socket not found after 15s"'
 ExecStart=/usr/lib/hyprwhspr/bin/hyprwhspr
 Environment=HYPRWHSPR_ROOT=/usr/lib/hyprwhspr
 Restart=on-failure


### PR DESCRIPTION
## Summary

Fixes the Wayland environment race condition by checking for the socket file directly instead of the `WAYLAND_DISPLAY` environment variable.

## Problem

The previous fix (#35) checks for `$WAYLAND_DISPLAY` in the systemd service, but systemd user services don't inherit environment variables from the graphical session. This causes the check to always timeout with:

```
Warning: WAYLAND_DISPLAY not set after 15s
```

Even though the Wayland compositor is fully running, the service never sees the environment variable.

## Solution

Check for the Wayland socket file directly at `/run/user/$UID/wayland-*` instead of the environment variable. The socket file is created when the compositor starts and is a reliable indicator that Wayland is ready.

```bash
# Before (checks env var - never set in systemd services)
for i in $(seq 1 30); do [ -n "$WAYLAND_DISPLAY" ] && exit 0; sleep 0.5; done

# After (checks socket file - always exists when compositor is running)
for i in $(seq 1 30); do ls /run/user/$(id -u)/wayland-* >/dev/null 2>&1 && exit 0; sleep 0.5; done
```

## Testing

- Verified socket exists at `/run/user/1000/wayland-1` when Hyprland is running
- Service starts immediately after socket is detected instead of waiting 15 seconds