### PR TITLE
fix: ignore blank audio instead of pasting to clipboard

### DIFF
--- a/lib/main.py
+++ b/lib/main.py
@@ -276,8 +276,15 @@ class hyprwhsprApp:
             transcription = self.whisper_manager.transcribe_audio(audio_data)
             
             if transcription and transcription.strip():
-                self.current_transcription = transcription.strip()
-                
+                text = transcription.strip()
+
+                # Filter out Whisper's blank audio markers - don't touch clipboard
+                if text.lower().replace('_', ' ').strip('[]() ') in ('blank audio', 'blank'):
+                    print("[INFO] Blank audio detected - ignoring")
+                    return
+
+                self.current_transcription = text
+
                 # Inject text
                 self._inject_text(self.current_transcription)
             else:


### PR DESCRIPTION
## Summary
- When Whisper returns blank audio markers like `[BLANK_AUDIO]`, don't inject the text or touch the clipboard
- Prevents accidentally overwriting clipboard contents when the shortcut is triggered but no speech is detected

## Test plan
- Trigger the recording shortcut
- Don't speak (or speak very quietly)
- Stop recording
- Verify clipboard contents are unchanged (previously would paste `[BLANK_AUDIO]` or similar)