### PR TITLE
fix: handle unknown key codes in keyboard event loop

### DIFF
--- a/lib/src/global_shortcuts.py
+++ b/lib/src/global_shortcuts.py
@@ -416,7 +416,11 @@ class GlobalShortcuts:
     def _process_event(self, event):
         """Process individual keyboard events"""
         if event.type == ecodes.EV_KEY:
-            key_event = categorize(event)
+            try:
+                key_event = categorize(event)
+            except KeyError:
+                # Unknown key code (e.g., 254) - skip this event
+                return
             key_name = self._keycode_to_name(event.code)
             should_suppress = False
 


### PR DESCRIPTION
## Summary

When hyprwhspr listens for keyboard shortcuts, it reads raw keyboard events from `/dev/input/eventX`. Each key press has a numeric code (e.g., `KEY_A` = 30, `KEY_SPACE` = 57).

The `evdev` library's `categorize()` function converts these raw events into friendly objects. Internally, it looks up the key code in a dictionary:

```python
self.keycode = keys[event.code]  # KeyError if code not in dictionary
```

Key code 254 isn't a standard key - it's likely something keyd or another virtual keyboard emits for internal purposes. When evdev tried to look it up, it threw a `KeyError`, which bubbled up and crashed the entire keyboard event loop.

The event loop lives in a thread. Once it crashed, no more keyboard events were processed. But the main process stayed alive, so waybar still showed "RDY" green - it just couldn't hear the shortcut anymore.

## The fix

```python
try:
    key_event = categorize(event)
except KeyError:
    # Unknown key code (e.g., 254) - skip this event
    return
```

Instead of crashing on unknown key codes, we catch the exception and skip that event. The event loop keeps running, and the shortcut continues to work.