### PR TITLE
feat: hybrid tap/hold mode for recording shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ After installation, use the `hyprwhspr` CLI to manage your installation:
 
 ### Global hotkey modes
 
-hyprwhspr supports two configurable interaction modes:
+hyprwhspr supports three configurable interaction modes:
 
 **Toggle mode (default):**
 
@@ -113,6 +113,11 @@ hyprwhspr supports two configurable interaction modes:
 
 - **Hold `Super+Alt+D`** - Start dictation
 - **Release `Super+Alt+D`** - Stop dictation
+
+**Auto mode (hybrid tap/hold):**
+
+- **Tap** (< 400ms) - Toggle behavior: tap to start recording, tap again to stop
+- **Hold** (>= 400ms) - Push-to-talk behavior: hold to record, release to stop
 
 ## Configuration
 
@@ -127,12 +132,32 @@ Edit `~/.config/hyprwhspr/config.json`:
 }
 ```
 
-**Hybrid tap/hold mode** - hyprwhspr automatically detects your intent:
+**Toggle hotkey mode** (default) - press to start, press again to stop:
 
-- **Tap** (< 400ms) - Toggle mode: tap to start recording, tap again to stop
-- **Hold** (>= 400ms) - Push-to-talk mode: hold to record, release to stop
+```jsonc
+{
+    "recording_mode": "toggle"
+}
+```
 
-No configuration needed - both modes work with the same shortcut!
+**Push-to-talk mode** - hold to record, release to stop:
+
+```jsonc
+{
+    "recording_mode": "push_to_talk"
+}
+```
+
+**Auto mode (hybrid tap/hold)** - automatically detects your intent:
+
+```jsonc
+{
+    "recording_mode": "auto"
+}
+```
+
+- **Tap** (< 400ms) - Toggle behavior: tap to start recording, tap again to stop
+- **Hold** (>= 400ms) - Push-to-talk behavior: hold to record, release to stop
 
 **Realtime WebSocket** - low-latency streaming via OpenAI's Realtime API:
 
@@ -267,8 +292,6 @@ Examples:
 
 - **Supported formats**: `.ogg`, `.wav`, `.mp3`
 - **Fallback**: Uses defaults if custom files don't exist
-
-_Thanks for [the sounds](https://github.com/akx/Notifications), @akx!_
 
 **Text replacement:** Automatically converts spoken words to symbols / punctuation:
 

--- a/lib/src/config_manager.py
+++ b/lib/src/config_manager.py
@@ -15,6 +15,7 @@ class ConfigManager:
         # Default configuration values - minimal set for hyprwhspr
         self.default_config = {
             'primary_shortcut': 'SUPER+ALT+D',
+            'recording_mode': 'toggle',  # 'toggle' | 'push_to_talk' | 'auto' (hybrid tap/hold)
             'model': 'base',
             'threads': 4,           # Thread count for whisper processing
             'language': None,       # Language code for transcription (None = auto-detect, or 'en', 'nl', 'fr', etc.)
@@ -76,11 +77,28 @@ class ConfigManager:
                 with open(self.config_file, 'r', encoding='utf-8') as f:
                     loaded_config = json.load(f)
                     
+                # Migrate old push_to_talk config to recording_mode (before merging with defaults)
+                # Check the original loaded_config, not self.config (which has defaults merged)
+                migration_occurred = False
+                if 'push_to_talk' in loaded_config and 'recording_mode' not in loaded_config:
+                    if loaded_config['push_to_talk']:
+                        loaded_config['recording_mode'] = 'push_to_talk'
+                    else:
+                        loaded_config['recording_mode'] = 'toggle'
+                    # Remove old push_to_talk key from loaded config
+                    del loaded_config['push_to_talk']
+                    migration_occurred = True
+                
                 # Merge loaded config with defaults (preserving any new default keys)
                 self.config.update(loaded_config)
                 
                 # Attempt automatic migration of API key if needed
                 self.migrate_api_key_to_credential_manager()
+                
+                # Save migrated config if migration occurred
+                if migration_occurred:
+                    self.save_config()
+                    print("Migrated 'push_to_talk' config to 'recording_mode'")
                 
                 print(f"Configuration loaded from {self.config_file}")
             else:


### PR DESCRIPTION
## Summary

Replace the `push_to_talk` config option with automatic tap/hold detection that combines both modes into one intuitive behavior:

- **Tap** (< 400ms) - Toggle mode: tap to start recording, tap again to stop
- **Hold** (>= 400ms) - Push-to-talk mode: hold to record, release to stop

No configuration needed - both modes work automatically with the same shortcut!

## Why this change?

The previous approach required users to choose between toggle mode and push-to-talk mode via config. This hybrid approach gives users the best of both worlds:

- Quick tap for hands-free dictation (start recording, do something else, tap again to stop)
- Hold for quick corrections or short phrases (natural push-to-talk behavior)

## Changes

- **lib/main.py**: Track press timestamp and determine tap vs hold on release
- **lib/src/config_manager.py**: Remove deprecated `push_to_talk` config option
- **README.md**: Update documentation to explain hybrid behavior

## Breaking change

The `push_to_talk` config option is removed. Users who had this set to `true` will now get the same behavior automatically when holding the shortcut >= 400ms.

## Test plan

- [ ] Tap shortcut quickly (< 400ms) - should start recording and keep going after release
- [ ] Tap again while recording - should stop recording
- [ ] Hold shortcut (>= 400ms) and release - should start on press, stop on release
- [ ] Verify old `push_to_talk: true` configs don't cause errors (option is simply ignored)