### PR TITLE
Add keyboard clicking to hallucination markers

### DIFF
--- a/lib/main.py
+++ b/lib/main.py
@@ -384,7 +384,7 @@ class hyprwhsprApp:
 
                 # Filter out Whisper hallucination markers - don't touch clipboard
                 normalized = text.lower().replace('_', ' ').strip('[]() ')
-                hallucination_markers = ('blank audio', 'blank', 'video playback', 'music', 'music playing')
+                hallucination_markers = ('blank audio', 'blank', 'video playback', 'music', 'music playing', 'keyboard clicking')
                 if normalized in hallucination_markers:
                     print(f"[INFO] Whisper hallucination detected: {text!r} - ignoring")
                     self.audio_manager.play_error_sound()


### PR DESCRIPTION
Whisper sometimes returns "(keyboard clicking)" when it hears keyboard sounds instead of speech. This adds it to the hallucination markers list so it's filtered out like other non-speech detections.