### PR TITLE
fix: add limit to systemd restarts

### DIFF
--- a/config/systemd/hyprwhspr.service
+++ b/config/systemd/hyprwhspr.service
@@ -2,6 +2,8 @@
 Description=hyprwhspr stt
 Documentation=https://github.com/goodroot/hyprwhspr
 After=graphical-session.target pipewire.service ydotool.service
+StartLimitIntervalSec=300
+StartLimitBurst=5
 Requires=ydotool.service
 Wants=pipewire.service
 


### PR DESCRIPTION
## Summary
Add systemd restart limits to prevent infinite restart loops

## Problem
When hyprwhspr fails to start (e.g., due to config issues or unavailable input devices), the systemd service restarts indefinitely. With `RestartSec=2`, this can result in thousands of restarts, causing sustained CPU usage that's difficult to diagnose.

## Solution
Add `StartLimitIntervalSec=300` and `StartLimitBurst=5` to the systemd unit file. This limits restarts to 5 attempts within a 5-minute window, after which systemd marks the service as failed instead of continuing to retry.