### PR TITLE
Update script to use readlink for SCRIPT_DIR

### DIFF
--- a/bin/hyprwhspr
+++ b/bin/hyprwhspr
@@ -3,7 +3,7 @@
 # hyprwhspr launcher
 
 # Get the directory where this script is located
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname $(readlink -f "$0"))" && pwd)"
 PACKAGE_ROOT="$(dirname "$SCRIPT_DIR")"
 
 # Set environment variables


### PR DESCRIPTION
```
$ hyprwhspr state
python: can't open file '/home/mte90/.local/lib/cli.py': [Errno 2] No such file or directory
```

I get this but if I run from the hyprwhspr folder everything is fine.

This one fixes because use the script path and not the one where is called with the symlink