### PR TITLE
fix: increase mic-osd verification timeout to 1.5s

### DIFF
--- a/lib/main.py
+++ b/lib/main.py
@@ -994,7 +994,7 @@ class hyprwhsprApp:
                 """Wait for callbacks and play sound if stream works"""
                 import time
                 start_time = time.monotonic()
-                while time.monotonic() - start_time < 0.5:  # Wait up to 500ms
+                while time.monotonic() - start_time < 1.5:  # Wait up to 1.5s
                     # Read frames_since_start with lock held to avoid data race
                     with self.audio_capture.lock:
                         frames_count = self.audio_capture.frames_since_start

--- a/lib/mic_osd/main.py
+++ b/lib/mic_osd/main.py
@@ -207,7 +207,7 @@ class MicOSD:
         # This prevents showing window when mic is unplugged but stream opens successfully
         import time
         verification_start = time.monotonic()
-        verification_duration = 0.25  # 250ms verification period
+        verification_duration = 1.5  # 1.5s verification period
         max_zero_level = 1e-6  # Threshold for considering audio as zero (very small)
         audio_detected = False
 


### PR DESCRIPTION
## Summary

- Increase mic-osd audio verification timeout from 250ms to 1.5s to prevent intermittent display failures

## Problem

The 250ms verification timeout was too short, causing the mic-osd to intermittently fail to display. It would detect zeros during the verification period and hide itself before audio data was detected.

Users experienced this as needing to press the hotkey 2-3 times before the visual feedback appeared.

## Solution

Increase the verification timeout to 1.5s. This gives sufficient time for audio to be detected while still providing reasonably quick feedback for unplugged/unavailable mics.

## Test plan

- [x] Verify mic-osd appears consistently on first hotkey press
- [x] Verify unplugged mic still causes mic-osd to hide (within 1.5s)

Fixes #97

🤖 Generated with [Claude Code](https://claude.ai/code)