### PR TITLE
Update device name matching condition

### DIFF
--- a/lib/src/global_shortcuts.py
+++ b/lib/src/global_shortcuts.py
@@ -271,7 +271,7 @@ class GlobalShortcuts:
                                 device_name_lower = device.name.lower()
                                 processed_paths.add(device.path)
                                 # Check for exact match or partial match
-                                if device_name_lower == search_name_lower or search_name_lower in device_name_lower:
+                                if device_name_lower == search_name_lower or search_name_lower == device_name_lower:
                                     matching_devices.append(device)
                                 else:
                                     device.close()


### PR DESCRIPTION
Refine device name matching logic to check for exact matches only.

Otherwise:

```
[ERROR] This device is incompatible with the configured shortcut
[WARN] Multiple devices match 'SEMITEK USB-HID Gaming Keyboard':
[WARN]   - SEMITEK USB-HID Gaming Keyboard Mouse (/dev/input/event10)
[WARN]   - SEMITEK USB-HID Gaming Keyboard (/dev/input/event9)
[WARN]   - SEMITEK USB-HID Gaming Keyboard Consumer Control (/dev/input/event8)
[WARN]   - SEMITEK USB-HID Gaming Keyboard System Control (/dev/input/event7)
[WARN]   - SEMITEK USB-HID Gaming Keyboard (/dev/input/event6)
[WARN] Using first match: SEMITEK USB-HID Gaming Keyboard Mouse (/dev/input/event10)
[ERROR] Selected device 'SEMITEK USB-HID Gaming Keyboard Mouse' (/dev/input/event10) cannot emit all keys required for shortcut 'SUPER+C'
```