### PR TITLE
fix(cli): detect ydotool version via pacman for Arch-based distros

### DIFF
--- a/lib/src/cli_commands.py
+++ b/lib/src/cli_commands.py
@@ -167,6 +167,7 @@ def _check_ydotool_version() -> tuple[bool, str, str]:
 
     hyprwhspr requires ydotool 1.0+ for paste injection. Ubuntu/Debian apt
     repositories contain an outdated 0.1.x version that uses incompatible syntax.
+    Arch-based distros (Arch, Manjaro, CachyOS) typically have 1.0+ in their repos.
 
     Returns:
         Tuple of (is_compatible, version_string, message)
@@ -197,6 +198,22 @@ def _check_ydotool_version() -> tuple[bool, str, str]:
             version = match.group(1)
     except Exception:
         pass
+
+    # Try pacman (Arch/Manjaro/CachyOS)
+    if not version:
+        try:
+            result = subprocess.run(
+                ['pacman', '-Q', 'ydotool'],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            # Output format: "ydotool 1.0.4-2.1"
+            match = re.search(r'ydotool\s+(\d+\.\d+\.?\d*)', result.stdout)
+            if match:
+                version = match.group(1)
+        except Exception:
+            pass
 
     # Fallback: try --version (old ydotool 0.1.x supports this)
     if not version:


### PR DESCRIPTION
## Summary
- Add pacman version detection for Arch-based systems (Arch, Manjaro, CachyOS)
- Fixes false-positive "ydotool 0.1.0 is too old" warnings on Arch when ydotool 1.0+ is installed

## Problem
On Arch-based systems, the version check incorrectly reports ydotool as 0.1.0 because:
1. `dpkg` doesn't exist (Debian/Ubuntu only)
2. `ydotool --version` doesn't work on 1.0+
3. Code falls back to assuming 0.1.0

## Solution
Add `pacman -Q ydotool` check between the dpkg and --version fallback attempts.

## Test plan
- [x] Verified `pacman -Q ydotool` output format: `ydotool 1.0.4-2.1`
- [x] Regex matches version correctly
- [ ] Run `hyprwhspr setup` on Arch - should detect 1.0.4 as compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)