### PR TITLE
Add contextlib import to whisper_manager.py

### DIFF
--- a/lib/src/whisper_manager.py
+++ b/lib/src/whisper_manager.py
@@ -6,6 +6,7 @@ PyWhisperCPP-only backend (in-process, model kept hot)
 import os
 import shutil
 import sys
+import contextlib
 import threading
 import time
 import types


### PR DESCRIPTION
Fix NameError by importing contextlib, I think it broke with recent refactor.