### PR TITLE
Bump MAX_COMPATIBLE_PYTHON to (3, 14)

### DIFF
--- a/lib/src/backend_installer.py
+++ b/lib/src/backend_installer.py
@@ -84,7 +84,7 @@ def _safe_decode(output) -> str:
 
 
 # Maximum Python version compatible with ML packages (onnxruntime, etc.)
-MAX_COMPATIBLE_PYTHON = (3, 13)
+MAX_COMPATIBLE_PYTHON = (3, 14)
 
 
 def _get_python_version(python_path: str) -> Optional[Tuple[int, int]]:


### PR DESCRIPTION
## Summary

- Bumps `MAX_COMPATIBLE_PYTHON` from `(3, 13)` to `(3, 14)` in `backend_installer.py`
- Arch Linux now ships Python 3.14 as the system default, causing the venv to fall back to older versions (e.g. 3.11) that can't access system site-packages like `python-gobject` and GTK4, breaking the mic-osd overlay
- Tested: pywhispercpp 1.4.1 builds from source and works on 3.14 with CUDA backend

Fixes #114

## Test plan

- [x] Verified venv creates with Python 3.14
- [x] Verified `pywhispercpp` builds and imports on 3.14
- [x] Verified GTK4 / mic-osd works in the 3.14 venv
- [x] Verified CUDA backend functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)