### PR TITLE
Fix _keycode_to_name crash when evdev returns a list for keycode lookup

### DIFF
--- a/lib/src/global_shortcuts.py
+++ b/lib/src/global_shortcuts.py
@@ -520,8 +520,8 @@ class GlobalShortcuts:
         """Convert evdev keycode to human readable name"""
         try:
             key_name = ecodes.KEY[keycode]
-            # Handle case where evdev returns a tuple of multiple event codes
-            if isinstance(key_name, tuple):
+            # Handle case where evdev returns a list/tuple of multiple event codes
+            if isinstance(key_name, (tuple, list)):
                 key_name = key_name[0]
             return key_name.replace('KEY_', '')
         except KeyError:


### PR DESCRIPTION
## Summary

`_keycode_to_name()` in `global_shortcuts.py` crashes with `AttributeError: 'list' object has no attribute 'replace'` when `evdev.ecodes.KEY[keycode]` returns a `list` instead of a `tuple` or `str`.

The existing code handles `tuple` but not `list`. Depending on the evdev version and keycode, either type can be returned when multiple key names share the same code.

## Fix

Change `isinstance(key_name, tuple)` to `isinstance(key_name, (tuple, list))`.

## Reproduction

Triggered during normal keyboard event processing — certain keycodes (e.g. keys with multiple evdev aliases) cause the event loop to crash, killing shortcut detection until the service restarts.