### PR TITLE
add GNOME/Wayland window detection via focused-window-dbus

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -692,6 +692,8 @@ hyprwhspr auto-detects the correct paste shortcut based on the focused window:
 - **Terminals** (Ghostty, Kitty, WezTerm, Alacritty, foot, etc.) → Ctrl+Shift+V
 - **Everything else** (editors, browsers, chat apps) → Ctrl+V
 
+**GNOME/Wayland:** Auto-detection requires the [Focused Window D-Bus](https://extensions.gnome.org/extension/5592/focused-window-d-bus/) GNOME Shell extension. Without it, hyprwhspr cannot detect the focused window and will default to Ctrl+V.
+
 No configuration needed for most setups. Override with `paste_mode` if your app needs something different:
 
 ```jsonc

--- a/lib/src/text_injector.py
+++ b/lib/src/text_injector.py
@@ -79,7 +79,8 @@ class TextInjector:
             return DEFAULT_PASTE_KEYCODE
 
     def _get_active_window_info(self) -> Optional[Dict[str, Any]]:
-        """Get active window info from Hyprland (if available)"""
+        """Get active window info from Hyprland or GNOME (focused-window-dbus extension)"""
+        # Try Hyprland first
         try:
             result = subprocess.run(
                 ['hyprctl', 'activewindow', '-j'],
@@ -89,6 +90,28 @@ class TextInjector:
                 return json.loads(result.stdout)
         except Exception:
             pass
+
+        # Fallback: GNOME with focused-window-dbus extension
+        try:
+            result = subprocess.run(
+                ['gdbus', 'call', '--session',
+                 '--dest', 'org.gnome.Shell',
+                 '--object-path', '/org/gnome/shell/extensions/FocusedWindow',
+                 '--method', 'org.gnome.shell.extensions.FocusedWindow.Get'],
+                capture_output=True, text=True, timeout=0.5
+            )
+            if result.returncode == 0:
+                # gdbus wraps output in ('...',) — extract the JSON string
+                raw = result.stdout.strip()
+                if raw.startswith("('") and raw.endswith("',)"):
+                    raw = raw[2:-3]
+                info = json.loads(raw)
+                # Normalize to match hyprctl format: map wm_class -> class
+                info['class'] = info.get('wm_class', '')
+                return info
+        except Exception:
+            pass
+
         return None
 
     def _is_terminal(self, window_info: Optional[Dict[str, Any]] = None) -> bool:
@@ -106,6 +129,7 @@ class TextInjector:
             'foot',
             'konsole', 'org.kde.konsole',
             'gnome-terminal', 'org.gnome.terminal',
+            'ptyxis', 'org.gnome.ptyxis',
             'xfce4-terminal',
             'terminator',
             'tilix',


### PR DESCRIPTION
- On GNOME/Wayland, `hyprctl activewindow -j` is unavailable — `_get_active_window_info()` now falls back to a `gdbus` call using the [Focused Window D-Bus](https://extensions.gnome.org/extension/5592/focused-window-d-bus/) GNOME Shell extension
- Add Ptyxis (`org.gnome.Ptyxis`) to the terminal detection list — this is the default terminal on Fedora 41+
- Document the extension requirement in CONFIGURATION.md under paste mode auto-detection

Tested on Fedora 43, GNOME/Wayland, Ptyxis terminal — correctly detects window class and uses Ctrl+Shift+V for paste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)