### PR TITLE
feat: capture the current transcription

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -973,6 +973,12 @@ hyprwhspr record toggle --lang it   # Toggle with language override
 
 # Check current status
 hyprwhspr record status
+
+# Capture: trigger a recording and stream the transcription to stdout
+# Blocks until transcription is complete. Suppresses text injection — use for scripting/piping.
+# Self-triggers a recording if none is in progress; attaches to an in-flight recording if one is.
+hyprwhspr record capture
+hyprwhspr record capture --lang it   # Capture with language override
 ```
 
 The `--lang` parameter overrides the default language for that recording session. 

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -169,7 +169,7 @@ def main():
                                       help='Language code for transcription (e.g., en, it, de)')
     record_capture_parser = record_subparsers.add_parser(
         'capture',
-        help='Trigger recording and stream the transcription to stdout'
+        help='Trigger recording and stream the transcription to stdout (suppresses text injection)'
     )
     record_capture_parser.add_argument('--lang', dest='language', metavar='CODE',
                                        help='Language code for transcription (e.g., en, it, de)')

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -36,6 +36,7 @@ from cli_commands import (
     uninstall_command,
     keyboard_command,
     record_command,
+    record_capture_command,
 )
 
 
@@ -166,6 +167,12 @@ def main():
     record_toggle_parser = record_subparsers.add_parser('toggle', help='Toggle recording on/off')
     record_toggle_parser.add_argument('--lang', dest='language', metavar='CODE',
                                       help='Language code for transcription (e.g., en, it, de)')
+    record_capture_parser = record_subparsers.add_parser(
+        'capture',
+        help='Trigger recording and stream the transcription to stdout'
+    )
+    record_capture_parser.add_argument('--lang', dest='language', metavar='CODE',
+                                       help='Language code for transcription (e.g., en, it, de)')
     record_subparsers.add_parser('status', help='Show current recording status')
     
     # backend command
@@ -298,7 +305,10 @@ def main():
             if not args.record_action:
                 record_parser.print_help()
                 sys.exit(1)
-            record_command(args.record_action, language=getattr(args, 'language', None))
+            if args.record_action == 'capture':
+                record_capture_command(language=getattr(args, 'language', None))
+            else:
+                record_command(args.record_action, language=getattr(args, 'language', None))
         elif args.command == 'uninstall':
             uninstall_command(
                 keep_models=getattr(args, 'keep_models', False),

--- a/lib/main.py
+++ b/lib/main.py
@@ -1544,6 +1544,7 @@ class hyprwhsprApp:
     def _inject_text(self, text):
         """Inject transcribed text into active application"""
 
+        # Capture mode: route text to client instead of injecting into active app
         if self._capture_subscriber is not None:
             self._notify_capture_subscriber(text, final=True)
             return
@@ -2060,19 +2061,22 @@ class hyprwhsprApp:
         Handler thread owns the connection fd and is the only closer.
         This method only writes; on final=True it signals the handler to close.
         """
-        subscriber = self._capture_subscriber
-        if subscriber is None:
-            return
+        with self._capture_subscriber_lock:
+            subscriber = self._capture_subscriber
+            if subscriber is None:
+                if final:
+                    self._capture_subscriber_done.set()
+                return
 
-        if text:
-            try:
-                subscriber.sendall(text.encode('utf-8'))
-            except (BrokenPipeError, ConnectionError, OSError) as e:
-                # handler select loop will detect disconnect and clean up.
-                print(f"[CAPTURE] Subscriber write failed: {e}", flush=True)
+            if text:
+                try:
+                    subscriber.sendall(text.encode('utf-8'))
+                except (BrokenPipeError, ConnectionError, OSError) as e:
+                    # handler select loop will detect disconnect and clean up.
+                    print(f"[CAPTURE] Subscriber write failed: {e}", flush=True)
 
-        if final:
-            self._capture_subscriber_done.set()
+            if final:
+                self._capture_subscriber_done.set()
 
     def _setup_capture_socket(self):
         """
@@ -2167,6 +2171,10 @@ class hyprwhsprApp:
             with self._capture_subscriber_lock:
                 if self._capture_subscriber is not None:
                     print("[CAPTURE] Rejecting — slot occupied", flush=True)
+                    try:
+                        conn.sendall(b"ERROR:slot_occupied\n")
+                    except OSError:
+                        pass
                     return
                 self._capture_subscriber = conn
                 self._capture_subscriber_done.clear()

--- a/lib/main.py
+++ b/lib/main.py
@@ -7,9 +7,11 @@ import sys
 import time
 import threading
 import os
+import socket
 import fcntl
 import atexit
 import subprocess
+import select
 from pathlib import Path
 
 try:
@@ -66,7 +68,7 @@ from device_monitor import DeviceMonitor, PYUDEV_AVAILABLE
 from paths import (
     RECORDING_STATUS_FILE, RECORDING_CONTROL_FILE, AUDIO_LEVEL_FILE, RECOVERY_REQUESTED_FILE,
     RECOVERY_RESULT_FILE, MIC_ZERO_VOLUME_FILE, LOCK_FILE, LONGFORM_STATE_FILE, LONGFORM_SEGMENTS_DIR,
-    MODEL_UNLOADED_FILE,
+    MODEL_UNLOADED_FILE, SOCKET_FILE
 )
 from backend_utils import normalize_backend
 from segment_manager import SegmentManager
@@ -144,6 +146,13 @@ class hyprwhsprApp:
         # Recording control FIFO (for immediate push-to-talk response)
         self._recording_control_thread = None  # Background thread handle for FIFO listener
         self._recording_control_stop = threading.Event()  # Signal to stop FIFO listener
+
+        # Capture socket state (for capture on the recording - streams transcription back to client)
+        self._capture_socket_thread = None  # Background thread handle for accepting socket connections
+        self._capture_socket_stop = threading.Event()  # Signal to stop for capture socket thread
+        self._capture_subscriber = None  # Active client connection, or None
+        self._capture_subscriber_lock = threading.Lock()  # Guards claim and release of subscriber connection
+        self._capture_subscriber_done = threading.Event()  # Set by notifier so that handler closes cleanly
 
         # Hybrid tap/hold mode state tracking (auto mode)
         recording_mode = self.config.get_setting('recording_mode', 'toggle')
@@ -793,6 +802,7 @@ class hyprwhsprApp:
             except Exception as e:
                 print(f"[CONTINUOUS] Transcription error: {e}", flush=True)
             finally:
+                self._notify_capture_subscriber("", final=True)
                 self._continuous_flush_lock.release()
                 self._continuous_transcription_done.set()
 
@@ -945,6 +955,7 @@ class hyprwhsprApp:
             return
 
         print("[LONGFORM] Recording cancelled (discarded)", flush=True)
+        self._notify_capture_subscriber("", final=True)
 
         try:
             self._stop_longform_auto_save_timer()
@@ -1042,6 +1053,7 @@ class hyprwhsprApp:
             self._write_longform_state('ERROR')
             self._set_visualizer_state('error')
         finally:
+            self._notify_capture_subscriber("", final=True)
             self.is_processing = False
 
     def _start_longform_auto_save_timer(self):
@@ -1342,6 +1354,8 @@ class hyprwhsprApp:
 
     def _cleanup_recording_state(self):
         """Best-effort cleanup after any recording ends. Safe to call multiple times."""
+        self._notify_capture_subscriber("", final=True)
+
         try:
             self._hide_mic_osd()
         except Exception:
@@ -1447,6 +1461,7 @@ class hyprwhsprApp:
                     self._notify_zero_volume("Audio stream broke during recording - no audio data captured. Try recording again after reseating.")
                 # Show error state and hide OSD
                 self._show_result_and_hide(False)
+                self._notify_capture_subscriber("", final=True)
             elif self._is_zero_volume(audio_data):
                 # Audio data exists but is all zeros - mic not producing sound
                 # Play error sound and notify user (may be intentional muting, but still inform)
@@ -1454,6 +1469,7 @@ class hyprwhsprApp:
                 self._notify_zero_volume("Microphone not producing audio (zero volume detected). This may be intentional muting, or the microphone may need to be reseated.")
                 # Show error state and hide OSD
                 self._show_result_and_hide(False)
+                self._notify_capture_subscriber("", final=True)
             else:
                 # Valid audio data - process it
                 self.audio_manager.play_stop_sound()
@@ -1464,6 +1480,7 @@ class hyprwhsprApp:
                 
         except Exception as e:
             print(f"[ERROR] Error stopping recording: {e}", flush=True)
+            self._notify_capture_subscriber("", final=True)
             # Ensure cleanup even if error occurs
             try:
                 self.is_recording = False
@@ -1519,12 +1536,18 @@ class hyprwhsprApp:
         except Exception as e:
             print(f"[ERROR] Error processing audio: {e}", flush=True)
         finally:
+            self._notify_capture_subscriber("", final=True)
             self.is_processing = False
             # Show success/error state and hide OSD after delay
             self._show_result_and_hide(success)
 
     def _inject_text(self, text):
         """Inject transcribed text into active application"""
+
+        if self._capture_subscriber is not None:
+            self._notify_capture_subscriber(text, final=True)
+            return
+
         try:
             self.text_injector.inject_text(text)
             print(f"[INJECT] Text injected ({len(text)} chars)", flush=True)
@@ -2030,6 +2053,183 @@ class hyprwhsprApp:
                     print(f"[CONTROL] Error in FIFO listener: {e}", flush=True)
                     time.sleep(0.1)  # Brief pause before retrying
 
+    def _notify_capture_subscriber(self, text, final):
+        """
+        Forward a transcription chunk to the active capture subscriber if any.
+
+        Handler thread owns the connection fd and is the only closer.
+        This method only writes; on final=True it signals the handler to close.
+        """
+        subscriber = self._capture_subscriber
+        if subscriber is None:
+            return
+
+        if text:
+            try:
+                subscriber.sendall(text.encode('utf-8'))
+            except (BrokenPipeError, ConnectionError, OSError) as e:
+                # handler select loop will detect disconnect and clean up.
+                print(f"[CAPTURE] Subscriber write failed: {e}", flush=True)
+
+        if final:
+            self._capture_subscriber_done.set()
+
+    def _setup_capture_socket(self):
+        """
+        Create unix-domain socket for `record capture` client requests.
+
+        Returns (sock: socket.socket or None)
+        """
+        try:
+            SOCKET_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+            # we do a cleanup at the startup to ensure no stale socket remains
+            if SOCKET_FILE.exists():
+                try:
+                    SOCKET_FILE.unlink()
+                    print("[INIT] Removed stale capture socket", flush=True)
+                except OSError as e:
+                    print(f"[WARN] Failed to remove stale capture socket: {e}", flush=True)
+                    return None
+
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.bind(str(SOCKET_FILE))
+            os.chmod(str(SOCKET_FILE), 0o600)
+            sock.listen(4)
+            sock.settimeout(1.0)
+            print(f"[INIT] Created capture socket: {SOCKET_FILE}", flush=True)
+
+            return sock
+        except OSError as e:
+            print(f"[WARN] Failed to create capture socket: {e}", flush=True)
+            print("[WARN] `record capture` will be unavailable this session", flush=True)
+
+            return None
+
+    def _capture_socket_listener(self):
+        """
+        Connection handler for the capture socket.
+        """
+        sock = self._setup_capture_socket()
+        if sock is None:
+            return
+
+        try:
+            while not self._capture_socket_stop.is_set():
+                try:
+                    conn, _ = sock.accept()
+                except socket.timeout:
+                    # proceed to check stop flag
+                    continue
+                except OSError as e:
+                    if self._capture_socket_stop.is_set():
+                        break
+                    print(f"[CAPTURE] Accept error: {e}", flush=True)
+                    time.sleep(0.1)
+                    continue
+
+                threading.Thread(
+                    target=self._handle_capture_connection,
+                    args=(conn,),
+                    daemon=True,
+                    name="CaptureConnectionHandler",
+                ).start()
+        finally:
+            try:
+                sock.close()
+            except OSError:
+                pass
+            try:
+                SOCKET_FILE.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    def _handle_capture_connection(self, conn):
+        """
+        Handle one capture client that is claiming the subscriber slot to receive transcription text.
+        """
+
+        try:
+            # fetch the request line with a timeout
+            conn.settimeout(1.0)
+            line = conn.recv(256).split(b"\n", 1)[0].decode("utf-8", errors="replace").strip()
+
+            verb, _, language = line.partition(":")
+            language = language.strip() or None
+
+            if verb != "capture":
+                print(f"[CAPTURE] Unknown request: {line!r}", flush=True)
+                return
+
+            conn.settimeout(None)
+
+            # claim the subscriber slot if available
+            with self._capture_subscriber_lock:
+                if self._capture_subscriber is not None:
+                    print("[CAPTURE] Rejecting — slot occupied", flush=True)
+                    return
+                self._capture_subscriber = conn
+                self._capture_subscriber_done.clear()
+
+            # trigger recording via fifo
+            if not self.is_recording:
+                cmd = f"start:{language}\n" if language else "start\n"
+                try:
+                    fd = os.open(str(RECORDING_CONTROL_FILE), os.O_WRONLY | os.O_NONBLOCK)
+                    try:
+                        os.write(fd, cmd.encode())
+                    finally:
+                        os.close(fd)
+                except OSError as e:
+                    print(f"[CAPTURE] Failed to self-trigger via FIFO: {e}", flush=True)
+
+            # either wait for recording to finish or for client disconnect
+            client_disconnected = False
+            while True:
+                if self._capture_subscriber_done.is_set():
+                    break
+                try:
+                    readable, _, _ = select.select([conn], [], [], 0.5)
+                except (OSError, ValueError):
+                    client_disconnected = True
+                    break
+                if readable:
+                    try:
+                        peek = conn.recv(1, socket.MSG_PEEK)
+                    except OSError:
+                        peek = b""
+                    if not peek:
+                        client_disconnected = True
+                        break
+
+            # we should cleanup if there was a premature disconnect
+            if client_disconnected and self.is_recording:
+                print("[CAPTURE] Client disconnected, cancelling recording", flush=True)
+                try:
+                    fd = os.open(str(RECORDING_CONTROL_FILE), os.O_WRONLY | os.O_NONBLOCK)
+                    try:
+                        os.write(fd, b"cancel\n")
+                    finally:
+                        os.close(fd)
+                except OSError:
+                    pass
+
+        except Exception as e:
+            print(f"[CAPTURE] Handler error: {e}", flush=True)
+        finally:
+            # clear lock since we are the owner
+            with self._capture_subscriber_lock:
+                if self._capture_subscriber is conn:
+                    self._capture_subscriber = None
+            try:
+                conn.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                conn.close()
+            except OSError:
+                pass
+
     def _attempt_recovery_if_needed(self):
         """
         Check for recovery request from tray script and attempt recovery once per error state.
@@ -2370,6 +2570,15 @@ class hyprwhsprApp:
         else:
             print("[WARN] Recording control FIFO not available, using fallback polling", flush=True)
 
+        # start capture socket listener thread
+        self._capture_socket_thread = threading.Thread(
+            target=self._capture_socket_listener,
+            daemon=True,
+            name="CaptureSocketListener",
+        )
+        self._capture_socket_thread.start()
+        print("[INIT] Started capture socket listener", flush=True)
+
         # Initialize whisper backend. Slow backends (e.g. cohere-transcribe loading a
         # 4 GB model onto the GPU) run in a background thread so shortcuts and the FIFO
         # listener are active immediately. Recording is blocked until ready.
@@ -2435,6 +2644,15 @@ class hyprwhsprApp:
                     self._recording_control_thread.join(timeout=1.0)
                     if self._recording_control_thread.is_alive():
                         print("[WARN] Recording control thread did not stop cleanly", flush=True)
+
+            # Stop capture socket listener thread
+            if hasattr(self, '_capture_socket_stop'):
+                self._capture_socket_stop.set()
+                if hasattr(self, '_capture_socket_thread') and self._capture_socket_thread and self._capture_socket_thread.is_alive():
+                    print("[SHUTDOWN] Stopping capture socket listener...", flush=True)
+                    self._capture_socket_thread.join(timeout=2.0)
+                    if self._capture_socket_thread.is_alive():
+                        print("[WARN] Capture socket thread did not stop cleanly", flush=True)
 
             # Stop background recovery thread
             if hasattr(self, '_background_recovery_stop'):

--- a/lib/src/cli_commands.py
+++ b/lib/src/cli_commands.py
@@ -9,6 +9,7 @@ import paths
 import subprocess
 import getpass
 import shutil
+import socket
 from pathlib import Path
 from typing import Optional
 
@@ -37,9 +38,9 @@ except ImportError:
     from config_manager import ConfigManager
 
 try:
-    from .paths import CONFIG_DIR, CONFIG_FILE, RECORDING_CONTROL_FILE, RECORDING_STATUS_FILE, MODEL_UNLOADED_FILE
+    from .paths import CONFIG_DIR, CONFIG_FILE, RECORDING_CONTROL_FILE, SOCKET_FILE, RECORDING_STATUS_FILE, MODEL_UNLOADED_FILE
 except ImportError:
-    from paths import CONFIG_DIR, CONFIG_FILE, RECORDING_CONTROL_FILE, RECORDING_STATUS_FILE, MODEL_UNLOADED_FILE
+    from paths import CONFIG_DIR, CONFIG_FILE, RECORDING_CONTROL_FILE, SOCKET_FILE,RECORDING_STATUS_FILE, MODEL_UNLOADED_FILE
 
 try:
     from .backend_utils import BACKEND_DISPLAY_NAMES, normalize_backend
@@ -5033,3 +5034,44 @@ def record_command(action: str, language: str = None):
         log_error(f"Unknown action: {action}")
         log_info("Available actions: start, stop, cancel, toggle, status")
 
+
+def record_capture_command(language: str = None):
+    """
+    Connect to the capture socket, trigger a recording, stream the transcription to stdout.
+
+    Blocks until the daemon closes the connection. If daemon is idle, this self-triggers a recording via the socket.
+    If daemon is already recording, this attaches to the in-flight transcription.
+
+    Args:
+      language: Language code (e.g., 'en', 'it', 'fr') or None for auto-detect
+    """
+
+    if not SOCKET_FILE.exists():
+        log_error("Capture socket not found.")
+        log_error("Is the hyprwhspr service running?")
+        log_error("Start it with: systemctl --user start hyprwhspr")
+        sys.exit(1)
+
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+            s.connect(str(SOCKET_FILE))
+            request = "capture"
+            if language:
+                request += f":{language}"
+            request += "\n"
+            s.sendall(request.encode())
+
+            while True:
+                chunk = s.recv(4096)
+                if not chunk:
+                    break
+                sys.stdout.buffer.write(chunk)
+                sys.stdout.flush()
+    except KeyboardInterrupt:
+        sys.exit(130)
+    except ConnectionRefusedError:
+        log_error("Capture socket refused connection. Daemon may be shutting down.")
+        sys.exit(1)
+    except OSError as e:
+        log_error(f"Capture socket error: {e}")
+        sys.exit(1)

--- a/lib/src/cli_commands.py
+++ b/lib/src/cli_commands.py
@@ -40,7 +40,7 @@ except ImportError:
 try:
     from .paths import CONFIG_DIR, CONFIG_FILE, RECORDING_CONTROL_FILE, SOCKET_FILE, RECORDING_STATUS_FILE, MODEL_UNLOADED_FILE
 except ImportError:
-    from paths import CONFIG_DIR, CONFIG_FILE, RECORDING_CONTROL_FILE, SOCKET_FILE,RECORDING_STATUS_FILE, MODEL_UNLOADED_FILE
+    from paths import CONFIG_DIR, CONFIG_FILE, RECORDING_CONTROL_FILE, SOCKET_FILE, RECORDING_STATUS_FILE, MODEL_UNLOADED_FILE
 
 try:
     from .backend_utils import BACKEND_DISPLAY_NAMES, normalize_backend
@@ -5061,10 +5061,17 @@ def record_capture_command(language: str = None):
             request += "\n"
             s.sendall(request.encode())
 
+            first = True
             while True:
                 chunk = s.recv(4096)
                 if not chunk:
                     break
+                if first:
+                    first = False
+                    if chunk.startswith(b"ERROR:"):
+                        msg = chunk.decode().strip().removeprefix("ERROR:")
+                        log_error(f"Capture rejected: {msg}")
+                        sys.exit(1)
                 sys.stdout.buffer.write(chunk)
                 sys.stdout.flush()
     except KeyboardInterrupt:

--- a/lib/src/paths.py
+++ b/lib/src/paths.py
@@ -18,6 +18,7 @@ CONFIG_FILE = CONFIG_DIR / 'config.json'
 # Runtime state signal files (used for IPC between service and waybar)
 RECORDING_STATUS_FILE = CONFIG_DIR / 'recording_status'
 RECORDING_CONTROL_FILE = CONFIG_DIR / 'recording_control'
+SOCKET_FILE = CONFIG_DIR / 'hyprwhspr.sock'
 AUDIO_LEVEL_FILE = CONFIG_DIR / 'audio_level'
 RECOVERY_REQUESTED_FILE = CONFIG_DIR / 'recovery_requested'
 RECOVERY_RESULT_FILE = CONFIG_DIR / 'recovery_result'


### PR DESCRIPTION
So I have gone with the following approach, which deviated a bit from what you suggested, hope you would still be happy with it.

- We always create a persistent socket at `CONFIG/hyprwhspr.socket` when the application runs.
- We guard this socket to only have one listener at a time.
- All the other commands work as before.
- We have one new command, which is `record capture`, which hooks into this socket creates a new recording or hijacks the current transcription if there was one going on.
- You can still use `record stop` but whenever we have a socket open it will not do any further action.

Why was this devitation, you might ask? I think we can also get the realtime transcription working with this, with a bit of effort.

Seemingly working which is cool.
<img width="3840" height="1600" alt="image" src="https://github.com/user-attachments/assets/fb00e6e8-3aeb-401c-88b6-10639783d231" />

fixes #162 