### PR TITLE
feat(config): extend environment variables in the credentials file

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -34,6 +34,20 @@ Only 2 essential options:
 }
 ```
 
+## Environment variable substitution
+
+Both `config.json` and `credentials.json` support `${VAR}` tokens. 
+
+Tokens are stored as-is on disk and expanded at read time
+
+```json
+{
+  "rest_api_key": "${OPENAI_API_KEY}"
+}
+```
+
+---
+
 ## Recording modes
 
 ### Toggle mode
@@ -69,7 +83,7 @@ Hybrid tap/hold - automatically detects your intent:
 - **Tap** (< 400ms) - Toggle behavior: tap to start recording, tap again to stop
 - **Hold** (>= 400ms) - Push-to-talk behavior: hold to record, release to stop
 
-### Continuous mode (Experimental)
+### Continuous mode
 
 Press to start, speak naturally, and when you pause for a couple seconds the text is automatically transcribed and pasted. 
 
@@ -86,7 +100,9 @@ Press again to stop:
 - Recording continues after each auto-paste, so you can keep dictating
 - To make it "faster", lower continous silence threshold
 - The final press stops recording and pastes any remaining audio
-- The silence threshold is auto-calibrated from your mic's noise floor at the start of each session. If detection feels off, set `continuous_silence_threshold` manually (check logs for the auto-calibrated value as a starting point)
+- The silence threshold is auto-calibrated from your mic's noise floor at the start of each session. 
+- If detection feels off, set `continuous_silence_threshold` manually (check logs for the auto-calibrated value)
+- Please report any issues you might experience with this functionality so it can be polished. 
 
 ### Long-form mode
 

--- a/lib/src/config_manager.py
+++ b/lib/src/config_manager.py
@@ -5,8 +5,30 @@ Handles loading, saving, and managing application settings
 
 import copy
 import json
+import os
+import re
 from pathlib import Path
 from typing import Any, Dict
+
+
+# Environment variable substitution: ${VAR} -> value of $VAR, or literal token if unset.
+# Applied lazily in get_setting() so save_config preserves the original tokens.
+_ENV_PATTERN = re.compile(r'\$\{([A-Za-z_][A-Za-z0-9_]*)\}')
+
+
+def _expand_env(value: Any) -> Any:
+    """Recursively expand ${VAR} in strings. Non-strings pass through."""
+    if isinstance(value, str):
+        def repl(m: 're.Match[str]') -> str:
+            env_val = os.environ.get(m.group(1))
+            return env_val if env_val is not None else m.group(0)
+
+        return _ENV_PATTERN.sub(repl, value)
+    if isinstance(value, dict):
+        return {k: _expand_env(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_expand_env(v) for v in value]
+    return value
 
 try:
     from .paths import CONFIG_DIR, CONFIG_FILE, TEMP_DIR
@@ -228,8 +250,8 @@ class ConfigManager:
             return False
     
     def get_setting(self, key: str, default: Any = None) -> Any:
-        """Get a configuration setting"""
-        return self.config.get(key, default)
+        """Get a configuration setting with environment variable expansion applied."""
+        return _expand_env(self.config.get(key, default))
     
     def set_setting(self, key: str, value: Any):
         """Set a configuration setting"""

--- a/lib/src/config_manager.py
+++ b/lib/src/config_manager.py
@@ -16,7 +16,7 @@ from typing import Any, Dict
 _ENV_PATTERN = re.compile(r'\$\{([A-Za-z_][A-Za-z0-9_]*)\}')
 
 
-def _expand_env(value: Any) -> Any:
+def expand_env(value: Any) -> Any:
     """Recursively expand ${VAR} in strings. Non-strings pass through."""
     if isinstance(value, str):
         def repl(m: 're.Match[str]') -> str:
@@ -25,9 +25,9 @@ def _expand_env(value: Any) -> Any:
 
         return _ENV_PATTERN.sub(repl, value)
     if isinstance(value, dict):
-        return {k: _expand_env(v) for k, v in value.items()}
+        return {k: expand_env(v) for k, v in value.items()}
     if isinstance(value, list):
-        return [_expand_env(v) for v in value]
+        return [expand_env(v) for v in value]
     return value
 
 try:
@@ -250,8 +250,14 @@ class ConfigManager:
             return False
     
     def get_setting(self, key: str, default: Any = None) -> Any:
-        """Get a configuration setting with environment variable expansion applied."""
-        return _expand_env(self.config.get(key, default))
+        """Get a configuration setting with environment variable expansion applied.
+
+        ${VAR} tokens in string values are replaced with the corresponding
+        environment variable. Unset variables are left as the literal token
+        (e.g. "${MY_KEY}" stays if MY_KEY is unset). Expansion always returns
+        strings — callers expecting int/float/bool must cast the result themselves.
+        """
+        return expand_env(self.config.get(key, default))
     
     def set_setting(self, key: str, value: Any):
         """Set a configuration setting"""

--- a/lib/src/credential_manager.py
+++ b/lib/src/credential_manager.py
@@ -18,6 +18,11 @@ try:
 except ImportError:
     from paths import CREDENTIALS_DIR, CREDENTIALS_FILE
 
+try:
+    from .config_manager import _expand_env
+except ImportError:
+    from config_manager import _expand_env
+
 
 def _ensure_credentials_dir():
     """Ensure credentials directory exists"""
@@ -89,16 +94,17 @@ def save_credential(provider: str, key: str) -> bool:
 
 def get_credential(provider: str) -> Optional[str]:
     """
-    Retrieve API key for a provider.
-    
+    Retrieve API key for a provider. Supports ${VAR} expansion against env vars.
+
     Args:
         provider: Provider identifier
-    
+
     Returns:
         API key if found, None otherwise
     """
     credentials = _load_credentials()
-    return credentials.get(provider)
+    value = credentials.get(provider)
+    return _expand_env(value) if isinstance(value, str) else value
 
 
 def list_credentials() -> Dict[str, str]:

--- a/lib/src/credential_manager.py
+++ b/lib/src/credential_manager.py
@@ -19,9 +19,9 @@ except ImportError:
     from paths import CREDENTIALS_DIR, CREDENTIALS_FILE
 
 try:
-    from .config_manager import _expand_env
+    from .config_manager import expand_env
 except ImportError:
-    from config_manager import _expand_env
+    from config_manager import expand_env
 
 
 def _ensure_credentials_dir():
@@ -104,7 +104,7 @@ def get_credential(provider: str) -> Optional[str]:
     """
     credentials = _load_credentials()
     value = credentials.get(provider)
-    return _expand_env(value) if isinstance(value, str) else value
+    return expand_env(value) if isinstance(value, str) else value
 
 
 def list_credentials() -> Dict[str, str]:
@@ -115,6 +115,7 @@ def list_credentials() -> Dict[str, str]:
         Dictionary mapping provider to masked key (e.g., 'sk-...****')
     """
     credentials = _load_credentials()
+    # ${VAR} tokens are not expanded here — they appear as literals in masked output.
     masked = {}
     
     for provider, key in credentials.items():


### PR DESCRIPTION
Hello again,

Sorry for the spam.

Another quick PR just to have config/credentials file support environment variable expansion.

This is stolen from the usual `.json` style of environment variable injection for things like editor configurations and mcp servers lately.