### PR TITLE
feat: opt-in keyboard hotplug via keyboard_device_names allowlist

### DIFF
--- a/lib/main.py
+++ b/lib/main.py
@@ -243,6 +243,7 @@ class hyprwhsprApp:
             grab_keys = self.config.get_setting("grab_keys", False)
             selected_device_path = self.config.get_setting("selected_device_path", None)
             selected_device_name = self.config.get_setting("selected_device_name", None)
+            keyboard_device_names = self.config.get_setting("keyboard_device_names", None)
 
             # Register callbacks based on recording mode
             # Validate recording_mode and only register release callback for modes that need it
@@ -255,6 +256,7 @@ class hyprwhsprApp:
                     device_path=selected_device_path,
                     device_name=selected_device_name,
                     grab_keys=grab_keys,
+                    keyboard_device_names=keyboard_device_names,
                 )
             elif recording_mode in ('push_to_talk', 'auto'):
                 # Push-to-talk and auto modes: register both press and release callbacks
@@ -265,6 +267,7 @@ class hyprwhsprApp:
                     device_path=selected_device_path,
                     device_name=selected_device_name,
                     grab_keys=grab_keys,
+                    keyboard_device_names=keyboard_device_names,
                 )
             elif recording_mode == 'long_form':
                 # Long-form mode: primary key toggles recording/paused, no release callback
@@ -275,6 +278,7 @@ class hyprwhsprApp:
                     device_path=selected_device_path,
                     device_name=selected_device_name,
                     grab_keys=grab_keys,
+                    keyboard_device_names=keyboard_device_names,
                 )
                 # Initialize segment manager for long-form mode
                 max_size_mb = self.config.get_setting('long_form_temp_limit_mb', 500)
@@ -292,6 +296,7 @@ class hyprwhsprApp:
                     device_path=selected_device_path,
                     device_name=selected_device_name,
                     grab_keys=grab_keys,
+                    keyboard_device_names=keyboard_device_names,
                 )
         except Exception as e:
             print(f"[ERROR] Failed to initialize global shortcuts: {e}", flush=True)
@@ -312,6 +317,7 @@ class hyprwhsprApp:
                             device_path=selected_device_path,
                             device_name=selected_device_name,
                             grab_keys=grab_keys,
+                            keyboard_device_names=keyboard_device_names,
                         )
                     elif recording_mode in ('push_to_talk', 'auto'):
                         self.secondary_shortcuts = GlobalShortcuts(
@@ -321,6 +327,7 @@ class hyprwhsprApp:
                             device_path=selected_device_path,
                             device_name=selected_device_name,
                             grab_keys=grab_keys,
+                            keyboard_device_names=keyboard_device_names,
                         )
                     else:
                         # Invalid mode: default to toggle behavior
@@ -331,6 +338,7 @@ class hyprwhsprApp:
                             device_path=selected_device_path,
                             device_name=selected_device_name,
                             grab_keys=grab_keys,
+                            keyboard_device_names=keyboard_device_names,
                         )
                     
                     # Start the secondary shortcuts
@@ -356,6 +364,7 @@ class hyprwhsprApp:
                     device_path=selected_device_path,
                     device_name=selected_device_name,
                     grab_keys=grab_keys,
+                    keyboard_device_names=keyboard_device_names,
                 )
                 if self._cancel_shortcuts.start():
                     print(f"[INFO] Cancel shortcut registered: {cancel_shortcut_key}", flush=True)
@@ -378,6 +387,7 @@ class hyprwhsprApp:
                         device_path=selected_device_path,
                         device_name=selected_device_name,
                         grab_keys=grab_keys,
+                        keyboard_device_names=keyboard_device_names,
                     )
                     if self._longform_submit_shortcuts.start():
                         print(f"[INFO] Long-form submit shortcut registered: {submit_shortcut_key}", flush=True)

--- a/lib/src/cli_commands.py
+++ b/lib/src/cli_commands.py
@@ -4507,6 +4507,8 @@ def list_keyboards():
         shortcut = config.get_setting("primary_shortcut", "Super+Alt+D")
         selected_device_name = config.get_setting("selected_device_name", None)
         selected_device_path = config.get_setting("selected_device_path", None)
+        keyboard_device_names = config.get_setting("keyboard_device_names", None) or []
+        allowlist_lower = [n.lower() for n in keyboard_device_names]
         
         # Get available keyboards
         keyboards = get_available_keyboards(shortcut)
@@ -4536,10 +4538,21 @@ def list_keyboards():
                     break
         
         for i, kb in enumerate(keyboards, 1):
-            # Mark only the device that would actually be selected
-            marker = " [SELECTED]" if (i - 1) == selected_device_index else ""
+            name_lower = kb['name'].lower()
+            markers = []
+            if (i - 1) == selected_device_index:
+                markers.append("SELECTED")
+            if allowlist_lower and name_lower in allowlist_lower:
+                markers.append("ALLOWED")
+            # Virtual devices aren't real hardware — they're created by
+            # hyprwhspr itself or by ydotool. Don't put them in your allowlist.
+            if ('hyprwhspr' in name_lower
+                    or 'ydotoold' in name_lower
+                    or 'uinput' in name_lower):
+                markers.append("VIRTUAL")
+            marker_str = f" [{' '.join(markers)}]" if markers else ""
             print(f"  {i}. {kb['name']}")
-            print(f"     Path: {kb['path']}{marker}")
+            print(f"     Path: {kb['path']}{marker_str}")
         
         print("-" * 70)
         print(f"\nTotal: {len(keyboards)} accessible device(s)")
@@ -4548,12 +4561,40 @@ def list_keyboards():
             print(f"\nCurrently selected by name: '{selected_device_name}'")
         elif selected_device_path:
             print(f"\nCurrently selected by path: {selected_device_path}")
+        elif keyboard_device_names:
+            print(f"\nAllowlist active (keyboard_device_names), {len(keyboard_device_names)} device(s):")
+            for name in keyboard_device_names:
+                print(f"  - {name}")
+            print("Hotplug detection enabled for listed devices.")
+            # Surface allowlist entries that don't match any present device —
+            # helps the user catch typos vs. just-unplugged devices.
+            present_names = {kb['name'].lower() for kb in keyboards}
+            missing = [n for n in keyboard_device_names if n.lower() not in present_names]
+            if missing:
+                print("\nAllowlist entries not currently present on this system:")
+                for name in missing:
+                    print(f"  - {name}")
+                print("  (These may just be unplugged; if so, they'll be grabbed when plugged in.)")
         else:
-            print("\nNo specific device selected - using auto-detection")
+            print("\nNo specific device selected — using auto-detection.")
+            # Point the user at the allowlist in case auto-detection grabs a
+            # mouse or media controller. Use a real device name from this
+            # system as the example so it's obvious how to populate the list.
+            real_candidates = [kb for kb in keyboards
+                               if 'hyprwhspr' not in kb['name'].lower()
+                               and 'ydotoold' not in kb['name'].lower()
+                               and 'uinput' not in kb['name'].lower()]
+            example_name = real_candidates[0]['name'] if real_candidates else "My Keyboard"
+            print("\nTo enable keyboard hotplug detection (useful for laptops that dock)")
+            print("or to restrict grabbing when auto-detection grabs a mouse-like device,")
+            print("set an allowlist in ~/.config/hyprwhspr/config.json:")
+            print('  "keyboard_device_names": [')
+            print(f'    "{example_name}"')
+            print('  ]')
+            print("(Also enables hotplug for listed devices plugged in after startup.)")
         
-        print("\nTo select a device, add to your config (~/.config/hyprwhspr/config.json):")
+        print("\nOther single-device overrides (take priority over the allowlist):")
         print('  "selected_device_name": "Device Name"')
-        print('  or')
         print('  "selected_device_path": "/dev/input/eventX"')
         
     except Exception as e:

--- a/lib/src/cli_commands.py
+++ b/lib/src/cli_commands.py
@@ -4527,8 +4527,7 @@ def list_keyboards():
             search_name_lower = selected_device_name.lower()
             for i, kb in enumerate(keyboards):
                 kb_name_lower = kb['name'].lower()
-                # Match GlobalShortcuts logic: exact match OR partial match
-                if kb_name_lower == search_name_lower or search_name_lower in kb_name_lower:
+                if kb_name_lower == search_name_lower:
                     selected_device_index = i
                     break  # Use first match, same as GlobalShortcuts
         elif selected_device_path:

--- a/lib/src/config_manager.py
+++ b/lib/src/config_manager.py
@@ -55,6 +55,14 @@ class ConfigManager:
             'use_hypr_bindings': False,  # Use Hyprland compositor bindings instead of evdev (disables GlobalShortcuts)
             'selected_device_path': None,  # Specific keyboard device path (e.g., '/dev/input/event3')
             'selected_device_name': None,  # Specific keyboard device name (e.g., 'USB Keyboard') - takes priority over path if both set
+            # Optional allowlist of keyboard device names. Two effects:
+            # (1) restricts which devices are grabbed at startup — mice/media
+            #     controllers that advertise keyboard-shaped capabilities are
+            #     skipped; (2) enables pyudev-based hotplug detection for the
+            #     listed devices (docked keyboards work without service restart).
+            # Ignored when selected_device_name / selected_device_path is set.
+            # Null (default) = legacy behavior: startup-only discovery, no filter.
+            'keyboard_device_names': None,
             # Audio device persistence (for reliable device matching across reboots)
             'audio_device_id': None,        # PortAudio device index (can change on reboot)
             'audio_device_name': None,      # Human-readable device name (more stable)

--- a/lib/src/global_shortcuts.py
+++ b/lib/src/global_shortcuts.py
@@ -288,19 +288,18 @@ class GlobalShortcuts:
 
                 # Device selection: prefer name over path if both are provided
                 if self.selected_device_name:
-                    # Match by device name (case-insensitive partial match)
+                    # Match by device name (case-insensitive exact match)
                     selected_device = None
                     matching_devices = []
                     search_name_lower = self.selected_device_name.lower()
-                    processed_paths = set()  # Track which device paths we've processed
+                    processed_paths = set()
 
                     try:
                         for device in devices:
                             try:
                                 device_name_lower = device.name.lower()
                                 processed_paths.add(device.path)
-                                # Check for exact match or partial match
-                                if device_name_lower == search_name_lower or search_name_lower == device_name_lower:
+                                if device_name_lower == search_name_lower:
                                     matching_devices.append(device)
                                 else:
                                     device.close()
@@ -665,8 +664,6 @@ class GlobalShortcuts:
             return
 
         try:
-            # Skip our own UInput virtual keyboard to avoid a grab feedback loop.
-            # This is the mitigation for the keyboard-lockout failure mode.
             try:
                 name_lower = device.name.lower()
             except Exception:
@@ -676,7 +673,6 @@ class GlobalShortcuts:
                 device.close()
                 return
 
-            # Honor explicit device selection if configured.
             if self.selected_device_name:
                 if name_lower != self.selected_device_name.lower():
                     device.close()
@@ -686,12 +682,10 @@ class GlobalShortcuts:
                     device.close()
                     return
             elif self.keyboard_device_names:
-                # Allowlist mode: skip anything not on the list.
                 if name_lower not in self.keyboard_device_names:
                     device.close()
                     return
 
-            # Must support EV_KEY and all keys in the configured shortcut.
             try:
                 capabilities = device.capabilities()
             except (OSError, IOError):
@@ -910,6 +904,7 @@ class GlobalShortcuts:
             self.listener_thread = threading.Thread(target=self._event_loop, daemon=True)
             self.listener_thread.start()
             self.is_running = True
+            self._start_hotplug_monitor()
             return True
 
         try:
@@ -947,8 +942,6 @@ class GlobalShortcuts:
         Non-fatal if pyudev is unavailable or the monitor fails to start.
         """
         if not self.keyboard_device_names:
-            # Opt-in: only enable hotplug when the user has listed real
-            # keyboards. See docstring above for rationale.
             return
         if not PYUDEV_AVAILABLE:
             print("[HOTPLUG] pyudev not available; keyboards plugged in after "

--- a/lib/src/global_shortcuts.py
+++ b/lib/src/global_shortcuts.py
@@ -1257,21 +1257,17 @@ def get_available_keyboards(shortcut: Optional[str] = None) -> List[Dict[str, st
                 device.close()
                 continue
             
-            try:
-                # Test if we can access the device
-                device.grab()
-                device.ungrab()
-                
-                keyboards.append({
-                    'name': device.name,
-                    'path': device.path,
-                    'display_name': f"{device.name} ({device.path})"
-                })
-            except (OSError, IOError):
-                # Device not accessible, skip it
-                pass
-            finally:
-                device.close()
+            # If we got this far, we can read the device (opened successfully
+            # above). Don't test grab() here: when the service is running it
+            # already holds the grab exclusively and the test would fail, so
+            # `hyprwhspr keyboard list` would hide the very device the user
+            # is trying to look up. Read access is sufficient to list it.
+            keyboards.append({
+                'name': device.name,
+                'path': device.path,
+                'display_name': f"{device.name} ({device.path})"
+            })
+            device.close()
                 
     except Exception as e:
         print(f"Error getting available keyboards: {e}")

--- a/lib/src/global_shortcuts.py
+++ b/lib/src/global_shortcuts.py
@@ -21,6 +21,11 @@ except ImportError:
 evdev = require_package('evdev')
 from evdev import InputDevice, categorize, ecodes, UInput
 
+try:
+    from .keyboard_monitor import KeyboardMonitor, PYUDEV_AVAILABLE
+except ImportError:
+    from keyboard_monitor import KeyboardMonitor, PYUDEV_AVAILABLE  # noqa: F401
+
 
 # Layout detection for non-QWERTY keyboard layouts
 # X11 keycode = evdev keycode + 8
@@ -222,6 +227,10 @@ class GlobalShortcuts:
         self.keyboard_device_names = ([n.lower() for n in keyboard_device_names]
                                        if keyboard_device_names else None)
 
+        # Hotplug monitor: detects keyboards plugged in after startup (e.g. docking).
+        # Started in start(); stopped in stop(). Gated on a non-nil allowlist.
+        self.keyboard_monitor: Optional[KeyboardMonitor] = None
+
         # Device and event handling
         self.devices = []
         self.device_fds = {}
@@ -261,6 +270,22 @@ class GlobalShortcuts:
                 all_device_paths = evdev.list_devices()
                 devices = [evdev.InputDevice(path) for path in all_device_paths]
                 
+                # Never grab our own UInput virtual keyboard. Doing so creates
+                # a feedback loop (physical key -> virtual -> re-grab) that locks
+                # out all input. Relevant on service restart when a stale
+                # virtual-keyboard node may briefly still be present.
+                filtered = []
+                for device in devices:
+                    try:
+                        if 'hyprwhspr' in device.name.lower():
+                            device.close()
+                            continue
+                    except Exception:
+                        device.close()
+                        continue
+                    filtered.append(device)
+                devices = filtered
+
                 # Device selection: prefer name over path if both are provided
                 if self.selected_device_name:
                     # Match by device name (case-insensitive partial match)
@@ -613,6 +638,121 @@ class GlobalShortcuts:
         except Exception:
             pass
     
+    def _try_hotplug_add(self, path: str):
+        """Handle a udev 'add' event for /dev/input/eventN.
+
+        Called from KeyboardMonitor's observer thread. Opens the device,
+        applies the same filters as _discover_keyboards, and attaches it
+        to the live event loop if it qualifies.
+        """
+        if self.stop_event.is_set():
+            return
+
+        # Already monitored: common when the udev event races _discover_keyboards.
+        with self._device_lock:
+            if any(d.path == path for d in self.devices):
+                return
+
+        # InputDevice can fail transiently right after an add event. One cheap retry.
+        device = None
+        for _ in range(2):
+            try:
+                device = evdev.InputDevice(path)
+                break
+            except (OSError, IOError):
+                time.sleep(0.05)
+        if device is None:
+            return
+
+        try:
+            # Skip our own UInput virtual keyboard to avoid a grab feedback loop.
+            # This is the mitigation for the keyboard-lockout failure mode.
+            try:
+                name_lower = device.name.lower()
+            except Exception:
+                device.close()
+                return
+            if 'hyprwhspr' in name_lower:
+                device.close()
+                return
+
+            # Honor explicit device selection if configured.
+            if self.selected_device_name:
+                if name_lower != self.selected_device_name.lower():
+                    device.close()
+                    return
+            elif self.selected_device_path:
+                if device.path != self.selected_device_path:
+                    device.close()
+                    return
+            elif self.keyboard_device_names:
+                # Allowlist mode: skip anything not on the list.
+                if name_lower not in self.keyboard_device_names:
+                    device.close()
+                    return
+
+            # Must support EV_KEY and all keys in the configured shortcut.
+            try:
+                capabilities = device.capabilities()
+            except (OSError, IOError):
+                device.close()
+                return
+            if ecodes.EV_KEY not in capabilities:
+                device.close()
+                return
+            available_keys = set(capabilities[ecodes.EV_KEY])
+            if not self.target_keys.issubset(available_keys):
+                device.close()
+                return
+
+            # Grab only if the main grabbing pass has already run; otherwise the
+            # devices_grabbed bookkeeping and UInput re-emit path are out of sync.
+            if self.grab_keys:
+                if not self.devices_grabbed:
+                    device.close()
+                    return
+                try:
+                    device.grab()
+                except (OSError, IOError) as e:
+                    print(f"[HOTPLUG] Cannot grab {device.name} ({path}): {e}")
+                    device.close()
+                    return
+
+            with self._device_lock:
+                # Recheck under lock to avoid a double-add race.
+                if any(d.path == path for d in self.devices):
+                    try:
+                        if self.grab_keys:
+                            device.ungrab()
+                    except Exception:
+                        pass
+                    device.close()
+                    return
+                self.devices.append(device)
+                self.device_fds[device.fd] = device
+
+            print(f"[HOTPLUG] Keyboard attached: {device.name} ({path})")
+
+        except Exception as e:
+            print(f"[HOTPLUG] Error adding device {path}: {e}")
+            try:
+                device.close()
+            except Exception:
+                pass
+
+    def _remove_device_by_path(self, path: str):
+        """Handle a udev 'remove' event for /dev/input/eventN.
+
+        The event-loop's read-error path normally catches unplugs, but udev
+        removal is more deterministic and avoids a one-iteration lag.
+        """
+        if self.stop_event.is_set():
+            return
+        with self._device_lock:
+            victim = next((d for d in self.devices if d.path == path), None)
+        if victim is not None:
+            self._remove_device(victim)
+
     # Modifier keys that should never get "stuck" - always pass through releases
     MODIFIER_KEYS = {
         ecodes.KEY_LEFTCTRL, ecodes.KEY_RIGHTCTRL,
@@ -784,6 +924,7 @@ class GlobalShortcuts:
             self.listener_thread.start()
             self.is_running = True
 
+            self._start_hotplug_monitor()
             return True
 
         except Exception as e:
@@ -792,6 +933,39 @@ class GlobalShortcuts:
             traceback.print_exc()
             self._cleanup_key_grabbing()
             return False
+
+    def _start_hotplug_monitor(self):
+        """Start pyudev-based hotplug monitor for input devices.
+
+        Gated on a non-nil `keyboard_device_names` allowlist: by listing
+        real keyboards the user has consented to runtime device discovery
+        for those devices. Without an allowlist, aggressive hotplug can
+        grab mice and media controllers whose EV_KEY capabilities look
+        keyboard-shaped (e.g. Logitech multi-device mice), so we keep the
+        legacy startup-only discovery path.
+
+        Non-fatal if pyudev is unavailable or the monitor fails to start.
+        """
+        if not self.keyboard_device_names:
+            # Opt-in: only enable hotplug when the user has listed real
+            # keyboards. See docstring above for rationale.
+            return
+        if not PYUDEV_AVAILABLE:
+            print("[HOTPLUG] pyudev not available; keyboards plugged in after "
+                  "startup will require a service restart")
+            return
+        if self.keyboard_monitor is not None:
+            return
+        try:
+            self.keyboard_monitor = KeyboardMonitor(
+                on_add=self._try_hotplug_add,
+                on_remove=self._remove_device_by_path,
+            )
+            if not self.keyboard_monitor.start():
+                self.keyboard_monitor = None
+        except Exception as e:
+            print(f"[HOTPLUG] Failed to start keyboard monitor: {e}")
+            self.keyboard_monitor = None
 
     def _setup_key_grabbing(self) -> bool:
         """Set up UInput virtual keyboard and grab physical devices
@@ -890,6 +1064,14 @@ class GlobalShortcuts:
 
         try:
             self.stop_event.set()
+
+            # Stop the hotplug monitor first so we don't race with device teardown.
+            if self.keyboard_monitor is not None:
+                try:
+                    self.keyboard_monitor.stop()
+                except Exception as e:
+                    print(f"[HOTPLUG] Error stopping keyboard monitor: {e}")
+                self.keyboard_monitor = None
 
             if self.listener_thread and self.listener_thread.is_alive():
                 self.listener_thread.join(timeout=2.0)  # Increased from 1.0s to 2.0s

--- a/lib/src/global_shortcuts.py
+++ b/lib/src/global_shortcuts.py
@@ -210,13 +210,17 @@ KEY_ALIASES: dict[str, str] = {
 class GlobalShortcuts:
     """Handles global keyboard shortcuts using evdev for hardware-level capture"""
 
-    def __init__(self, primary_key: str = '<f12>', callback: Optional[Callable] = None, release_callback: Optional[Callable] = None, device_path: Optional[str] = None, device_name: Optional[str] = None, grab_keys: bool = True):
+    def __init__(self, primary_key: str = '<f12>', callback: Optional[Callable] = None, release_callback: Optional[Callable] = None, device_path: Optional[str] = None, device_name: Optional[str] = None, grab_keys: bool = True, keyboard_device_names: Optional[List[str]] = None):
         self.primary_key = primary_key
         self.callback = callback
         self.selected_device_path = device_path
         self.selected_device_name = device_name
         self.release_callback = release_callback
         self.grab_keys = grab_keys
+        # Allowlist: lower-cased for case-insensitive comparison.
+        # Ignored when selected_device_name/path is set (those are single-device overrides).
+        self.keyboard_device_names = ([n.lower() for n in keyboard_device_names]
+                                       if keyboard_device_names else None)
 
         # Device and event handling
         self.devices = []
@@ -346,6 +350,17 @@ class GlobalShortcuts:
                     devices = [selected_device]
                 
                 for device in devices:
+                    # Allowlist filter (only in auto-discover mode).
+                    # When keyboard_device_names is set, skip everything not on the list.
+                    # Prevents grabbing mice/media controllers that advertise enough
+                    # EV_KEY codes to pass the capability check below.
+                    if (self.keyboard_device_names
+                            and not self.selected_device_name
+                            and not self.selected_device_path):
+                        if device.name.lower() not in self.keyboard_device_names:
+                            device.close()
+                            continue
+
                     # Require EV_KEY events
                     capabilities = device.capabilities()
                     if ecodes.EV_KEY not in capabilities:

--- a/lib/src/keyboard_monitor.py
+++ b/lib/src/keyboard_monitor.py
@@ -1,0 +1,92 @@
+"""
+Keyboard hotplug monitor for hyprwhspr.
+Uses pyudev to detect when input (keyboard) devices are plugged or unplugged,
+so newly attached keyboards (e.g. a USB keyboard via a dock) can be grabbed
+without restarting the service.
+"""
+
+import threading
+
+try:
+    import pyudev
+    PYUDEV_AVAILABLE = True
+except ImportError:
+    PYUDEV_AVAILABLE = False
+
+
+class KeyboardMonitor:
+    """Monitor for input-subsystem hotplug events on /dev/input/event* nodes."""
+
+    def __init__(self, on_add=None, on_remove=None):
+        self.on_add = on_add
+        self.on_remove = on_remove
+        self.observer = None
+        self.monitor = None
+        self.context = None
+        self.is_running = False
+
+        if not PYUDEV_AVAILABLE:
+            print("[KEYBOARD_MONITOR] pyudev not available, keyboard hotplug disabled")
+
+    def start(self) -> bool:
+        """Start monitoring. Returns True on success."""
+        if not PYUDEV_AVAILABLE:
+            return False
+        if self.is_running:
+            return True
+
+        try:
+            self.context = pyudev.Context()
+            self.monitor = pyudev.Monitor.from_netlink(self.context)
+            self.monitor.filter_by(subsystem='input')
+
+            def handle_event(action, device):
+                try:
+                    devnode = device.device_node
+                    # Only care about the /dev/input/eventN nodes.
+                    # Parent input class devices without a device node also
+                    # fire events; they're not useful here.
+                    if not devnode or not devnode.startswith('/dev/input/event'):
+                        return
+
+                    if action == 'add' and self.on_add:
+                        threading.Thread(
+                            target=self.on_add,
+                            args=(devnode,),
+                            daemon=True,
+                        ).start()
+                    elif action == 'remove' and self.on_remove:
+                        threading.Thread(
+                            target=self.on_remove,
+                            args=(devnode,),
+                            daemon=True,
+                        ).start()
+                except Exception as e:
+                    print(f"[KEYBOARD_MONITOR] Error handling event: {e}")
+
+            self.observer = pyudev.MonitorObserver(self.monitor, handle_event)
+            self.observer.start()
+            self.is_running = True
+            print("[KEYBOARD_MONITOR] Started monitoring for keyboard hotplug events")
+            return True
+
+        except Exception as e:
+            print(f"[KEYBOARD_MONITOR] Failed to start: {e}")
+            self.is_running = False
+            return False
+
+    def stop(self):
+        """Stop monitoring."""
+        if not self.is_running:
+            return
+        if self.observer:
+            try:
+                self.observer.stop()
+            except Exception as e:
+                print(f"[KEYBOARD_MONITOR] Error stopping observer: {e}")
+            finally:
+                self.observer = None
+                self.monitor = None
+                self.context = None
+                self.is_running = False
+                print("[KEYBOARD_MONITOR] Stopped monitoring")

--- a/lib/src/keyboard_monitor.py
+++ b/lib/src/keyboard_monitor.py
@@ -5,6 +5,7 @@ so newly attached keyboards (e.g. a USB keyboard via a dock) can be grabbed
 without restarting the service.
 """
 
+import queue
 import threading
 
 try:
@@ -24,9 +25,25 @@ class KeyboardMonitor:
         self.monitor = None
         self.context = None
         self.is_running = False
+        self._event_queue: queue.Queue = queue.Queue()
+        self._worker: threading.Thread | None = None
 
         if not PYUDEV_AVAILABLE:
             print("[KEYBOARD_MONITOR] pyudev not available, keyboard hotplug disabled")
+
+    def _dispatch_loop(self):
+        while True:
+            item = self._event_queue.get()
+            if item is None:
+                break
+            action, devnode = item
+            try:
+                if action == 'add' and self.on_add:
+                    self.on_add(devnode)
+                elif action == 'remove' and self.on_remove:
+                    self.on_remove(devnode)
+            except Exception as e:
+                print(f"[KEYBOARD_MONITOR] Error handling event: {e}")
 
     def start(self) -> bool:
         """Start monitoring. Returns True on success."""
@@ -43,35 +60,38 @@ class KeyboardMonitor:
             def handle_event(action, device):
                 try:
                     devnode = device.device_node
-                    # Only care about the /dev/input/eventN nodes.
-                    # Parent input class devices without a device node also
-                    # fire events; they're not useful here.
+                    # Only /dev/input/eventN nodes are actionable; parent
+                    # input class devices without a node also fire events.
                     if not devnode or not devnode.startswith('/dev/input/event'):
                         return
-
-                    if action == 'add' and self.on_add:
-                        threading.Thread(
-                            target=self.on_add,
-                            args=(devnode,),
-                            daemon=True,
-                        ).start()
-                    elif action == 'remove' and self.on_remove:
-                        threading.Thread(
-                            target=self.on_remove,
-                            args=(devnode,),
-                            daemon=True,
-                        ).start()
+                    if action in ('add', 'remove'):
+                        self._event_queue.put((action, devnode))
                 except Exception as e:
                     print(f"[KEYBOARD_MONITOR] Error handling event: {e}")
 
             self.observer = pyudev.MonitorObserver(self.monitor, handle_event)
             self.observer.start()
+            # Start worker after observer so a failed observer leaves no stranded thread.
+            self._worker = threading.Thread(target=self._dispatch_loop, daemon=True)
+            self._worker.start()
             self.is_running = True
             print("[KEYBOARD_MONITOR] Started monitoring for keyboard hotplug events")
             return True
 
         except Exception as e:
             print(f"[KEYBOARD_MONITOR] Failed to start: {e}")
+            if self.observer:
+                try:
+                    self.observer.stop()
+                except Exception:
+                    pass
+                self.observer = None
+            if self._worker is not None:
+                self._event_queue.put(None)
+                self._worker.join(timeout=2.0)
+                self._worker = None
+            self.monitor = None
+            self.context = None
             self.is_running = False
             return False
 
@@ -90,3 +110,7 @@ class KeyboardMonitor:
                 self.context = None
                 self.is_running = False
                 print("[KEYBOARD_MONITOR] Stopped monitoring")
+        self._event_queue.put(None)
+        if self._worker:
+            self._worker.join(timeout=2.0)
+            self._worker = None

--- a/share/config.schema.json
+++ b/share/config.schema.json
@@ -56,6 +56,12 @@
       "default": null,
       "description": "Specific keyboard device name (e.g., 'USB Keyboard'). Takes priority over path if both set."
     },
+    "keyboard_device_names": {
+      "type": ["array", "null"],
+      "items": { "type": "string" },
+      "default": null,
+      "description": "Optional allowlist of keyboard device names. When set: (1) only listed devices are grabbed at startup; (2) pyudev-based hotplug detection is enabled so listed devices plugged in later (e.g. docking a laptop) are attached without restarting the service. Ignored if selected_device_name or selected_device_path is set. Null (default) = legacy startup-only discovery."
+    },
     "audio_device_id": {
       "type": ["integer", "null"],
       "default": null,


### PR DESCRIPTION
adds pyudev-based keyboard hotplug detection. mirrors the existing `device_monitor.py` pattern (which already watches `subsystem='sound'` for microphone hotplug) with a new `keyboard_monitor.py` that watches `subsystem='input'`.

**the problem:** `_discover_keyboards()` runs once at startup, so a keyboard plugged in later (docking a laptop, bluetooth reconnecting) is invisible until the service restarts. surfaced for me on a usb-c dock with an external keyboard.

**opt-in design:** a non-nil `keyboard_device_names` allowlist is the single switch.

- null (default) = legacy behavior, byte-identical to current upstream.
- set it, and two things happen: (1) startup discovery is filtered to listed devices only, (2) the pyudev observer starts, attaching listed devices plugged in later.

**why gate on the allowlist:** some input devices pass the `target_keys.issubset(available_keys)` capability filter without being keyboards. E.g. the logitech m720 triathlon mouse advertises 162 `EV_KEY` codes including `super`, `alt`, and common letters. without the allowlist, aggressive hotplug grabs these and breaks mouse operation after a dock cycle. making the allowlist the opt-in switch couples the two correctly: by listing real keyboards, the user has consented to runtime discovery of exactly those devices.

**config:**

```json
{
  "keyboard_device_names": [
    "AT Translated Set 2 keyboard",
    "SONiX USB Keyboard"
  ]
}
```

**self-grab prevention:** both discovery paths skip any device whose name contains `"hyprwhspr"`. grabbing our own `UInput` virtual keyboard creates a feedback loop (physical → virtual → re-grab) that locks out all input. relevant on in-process restart when a stale virtual-keyboard node may linger briefly.

**cli improvements to `hyprwhspr keyboard list`:**

- `[ALLOWED]` / `[VIRTUAL]` markers alongside `[SELECTED]`
- when auto-discover is active, prints a ready-to-paste allowlist snippet using a real device name from the system
- when an allowlist is set, warns about entries that don't match any present device (catches typos vs. just-unplugged)
- drops the `grab()/ungrab()` accessibility test in `get_available_keyboards()`; it failed on devices the running service already grabbed, hiding the primary keyboard from its own cli

**graceful degradation:** pyudev missing → observer doesn't start, allowlist still filters startup discovery. priority between single-device and allowlist config: `selected_device_name` > `selected_device_path` > `keyboard_device_names` > auto-discover. consistent between startup and hotplug paths.

**commits** (each self-contained and bisect-safe):

1. `feat: add keyboard_device_names allowlist` — config, schema, main.py threading, startup filter
2. `feat: auto-detect hotplugged keyboards via pyudev` — monitor, hotplug path, self-grab filter, start/stop wiring, gated on the allowlist from #1
3. `feat(cli): show allowlist status in keyboard list` — markers, guidance, drop stale test-grab

tested locally on an arch laptop across a dock cycle: external keyboard attaches in ~1s of plug-in, triathlon mouse correctly filtered, no lockups observed.