### PR TITLE
feat: add post_transcription_hook for user-defined text transforms

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -912,6 +912,37 @@ hyprwhspr saves your clipboard before injection and restores it automatically af
 
 The paste hotkey is sent via `wtype` (Wayland virtual-keyboard protocol), which works correctly in all applications including Kitty-protocol terminals (Ghostty, Kitty, WezTerm). `ydotool` is used as a fallback when `wtype` is not installed.
 
+### Post-transcription hook
+
+Pipe each transcription through a shell command before it's pasted. Stdin receives the (preprocessed) transcription; non-empty stdout replaces it. Empty stdout leaves the text unchanged, so the same mechanism works for both transforms and fire-and-forget observers.
+
+```json
+{
+    "post_transcription_hook": "sed 's|.*|<dictation>&</dictation>|'"
+}
+```
+
+The example above wraps every injected transcription in `<dictation>...</dictation>` — a useful signal to downstream LLMs that the text came from ASR and may contain transcription artifacts (homophones, proper-noun misspellings).
+
+Other patterns:
+
+```json
+// Archive transcriptions to a log, leave text unchanged (observer-only):
+{ "post_transcription_hook": "tee -a ~/.local/share/hyprwhspr/log.txt >/dev/null" }
+
+// User-provided transform script on $PATH:
+{ "post_transcription_hook": "~/.local/bin/filler-word-coach" }
+```
+
+Two environment variables are exported to the hook:
+
+- `HYPRWHSPR_MODEL` — the active whisper model
+- `HYPRWHSPR_BACKEND` — the active transcription backend
+
+The hook runs under a 5-second timeout. On timeout, non-zero exit, or any subprocess error, the original text is preserved — a broken hook will never silently eat a dictation. Errors are logged to the service journal.
+
+Note: the command runs under `shell=True`, so pipes, redirects, and command chaining work as expected. Treat `post_transcription_hook` as trusted config (same threat model as the rest of `config.json`).
+
 ## Integrations
 
 ### Waybar

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -926,11 +926,15 @@ The example above wraps every injected transcription in `<dictation>...</dictati
 
 Other patterns:
 
-```json
-// Archive transcriptions to a log, leave text unchanged (observer-only):
-{ "post_transcription_hook": "tee -a ~/.local/share/hyprwhspr/log.txt >/dev/null" }
+Archive transcriptions to a log, leave text unchanged (observer-only):
 
-// User-provided transform script on $PATH:
+```json
+{ "post_transcription_hook": "tee -a ~/.local/share/hyprwhspr/log.txt >/dev/null" }
+```
+
+User-provided transform script on `$PATH`:
+
+```json
 { "post_transcription_hook": "~/.local/bin/filler-word-coach" }
 ```
 

--- a/lib/src/config_manager.py
+++ b/lib/src/config_manager.py
@@ -75,6 +75,11 @@ class ConfigManager:
             'filler_words': ['uh', 'um', 'er', 'ah', 'eh', 'hmm', 'hm', 'mm', 'mhm'],  # Filler words to remove
             'symbol_replacements': True,  # Enable built-in speech-to-symbol replacements (e.g., "quote" → ")
             'whisper_prompt': 'Transcribe with proper capitalization, including sentence beginnings, proper nouns, titles, and standard English capitalization rules.',
+            # Shell command run after preprocessing, before paste. Stdin
+            # receives the transcription; non-empty stdout replaces it.
+            # Empty stdout leaves text unchanged (observer-only hooks).
+            # Null disables the hook.
+            'post_transcription_hook': None,
             'clipboard_behavior': False,  # Boolean: true = clear clipboard after delay, false = keep (current behavior)
             'clipboard_clear_delay': 5.0,  # Float: seconds to wait before clearing clipboard (only used if clipboard_behavior is true)
             # Values: "super" | "ctrl_shift" | "ctrl" | null (auto-detect)

--- a/lib/src/text_injector.py
+++ b/lib/src/text_injector.py
@@ -420,7 +420,8 @@ class TextInjector:
             return True
 
         # Preprocess; also trim trailing newlines (avoid unwanted Enter)
-        processed_text = self._preprocess_text(text).rstrip("\r\n") + ' '
+        processed_text = self._preprocess_text(text).rstrip("\r\n")
+        processed_text = self._run_post_transcription_hook(processed_text) + ' '
 
         try:
             inject_mode = None
@@ -508,6 +509,40 @@ class TextInjector:
         processed = processed.strip()
 
         return processed
+
+    def _run_post_transcription_hook(self, text: str) -> str:
+        """Pipe text through the user's post_transcription_hook shell command.
+
+        Stdin = text; non-empty stdout replaces it (empty stdout = observer-only).
+        Env: HYPRWHSPR_MODEL, HYPRWHSPR_BACKEND. 5s timeout. Any error
+        preserves the original text — a broken hook must never eat a dictation.
+        """
+        if not (self.config_manager and text):
+            return text
+        cmd = self.config_manager.get_setting('post_transcription_hook', None)
+        if not (isinstance(cmd, str) and cmd.strip()):
+            return text
+
+        env = os.environ.copy()
+        env['HYPRWHSPR_MODEL'] = str(self.config_manager.get_setting('model', '') or '')
+        env['HYPRWHSPR_BACKEND'] = str(self.config_manager.get_setting('transcription_backend', '') or '')
+
+        # shell=True is deliberate: the command is user-authored config, same trust
+        # level as the rest of config.json, and users rely on pipes/redirects/chains.
+        try:
+            result = subprocess.run(
+                cmd, shell=True, input=text, capture_output=True,
+                text=True, timeout=5.0, env=env,
+            )
+        except Exception as e:
+            print(f"post_transcription_hook failed: {e}")
+            return text
+        if result.returncode != 0:
+            stderr = (result.stderr or '').strip()
+            print(f"post_transcription_hook exited {result.returncode}: {stderr}")
+            return text
+        out = result.stdout.rstrip('\n')
+        return out if out else text
 
     def _apply_word_overrides(self, text: str) -> str:
         """Apply user-defined word overrides to the text"""

--- a/lib/src/text_injector.py
+++ b/lib/src/text_injector.py
@@ -535,13 +535,13 @@ class TextInjector:
                 text=True, timeout=5.0, env=env,
             )
         except Exception as e:
-            print(f"post_transcription_hook failed: {e}")
+            print(f"post_transcription_hook failed: {e}", flush=True)
             return text
         if result.returncode != 0:
             stderr = (result.stderr or '').strip()
-            print(f"post_transcription_hook exited {result.returncode}: {stderr}")
+            print(f"post_transcription_hook exited {result.returncode}: {stderr}", flush=True)
             return text
-        out = result.stdout.rstrip('\n')
+        out = result.stdout.rstrip("\r\n")
         return out if out else text
 
     def _apply_word_overrides(self, text: str) -> str:

--- a/share/config.schema.json
+++ b/share/config.schema.json
@@ -129,6 +129,11 @@
       "default": "Transcribe with proper capitalization, including sentence beginnings, proper nouns, titles, and standard English capitalization rules.",
       "description": "Prompt passed to Whisper to guide transcription style"
     },
+    "post_transcription_hook": {
+      "type": ["string", "null"],
+      "default": null,
+      "description": "Shell command run after preprocessing, before paste. Stdin receives the transcription; non-empty stdout replaces it. Empty stdout = observer-only (original text is kept). Env vars HYPRWHSPR_MODEL and HYPRWHSPR_BACKEND are set. Subject to a 5s timeout; errors pass through the original text."
+    },
     "clipboard_behavior": {
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
Adds a `post_transcription_hook` config: a shell command every transcription is piped through after preprocessing, before paste.

```json
{ "post_transcription_hook": "~/.local/bin/my-hook" }
```

or 

```json
{ "post_transcription_hook": "sed 's|.*|<dictation>&</dictation>|'" }
```

- stdin = the transcription
- non-empty stdout replaces it; empty stdout leaves it unchanged (observer-only hooks)
- `HYPRWHSPR_MODEL` and `HYPRWHSPR_BACKEND` exported to the hook
- 5 s timeout; on timeout, non-zero exit, or any subprocess error the original text is preserved

When unset, the hook method returns immediately after a config lookup — no subprocess, no string allocation, original `text` reference handed back. Semantically identical to how it is now.

### Why

Most of my hyprwhspr usage is dictating text into LLMs, and I'd wanted to wrap the output in `<dictation>...</dictation>` so the model knows it's ASR output and can be lenient about homophones and proper nouns. Then I can coach it in `CLAUDE.md` about how to interpret `<dictation>` tags. I do use a custom `whisper_prompt` and `word_overrides`, and thank you for making those available, but I've found this nicely complements those mechanisms.

Once the hook existed, two more uses fell out for free: archiving transcriptions to a log, and a filler-word script that pings `notify-send` when there are too many, like, filler words.

Different shape from `record capture` (#163) — that's a pull model for one-off wrappers; this is a push model running inline with injection and able to mutate the text.

### Alternatives considered

- **systemd path units** — need an observable signal (hyprwhspr writes to a socket, not a stable file per #163), and would fire *after* injection so they can observe but not transform. Rules out the `<dictation>` wrapping case.
- **Dedicated `transcription_llm_tag` config** — narrower, but the diff is about the same size as this, and this route seemed more useful
- **List of hooks** — considered, but a single entry point keeps the config surface minimal; a user who wants to do N things can write one script that does N things.

### Notes

- `subprocess.run` is already used 15× in `text_injector.py`; no new imports
- error handling matches the existing ydotool/wtype/hyprctl wrappers (`except Exception` → `print(...)` → fall through)
- `shell=True` is the one novel pattern in the file. Deliberate — pipes/chaining/`~` expansion are the point, and the command is from `config.json` (same trust level as the rest of it). Commented at the call site.

Docs entry mirrors `### Clipboard behavior`.

Thanks again for the work on this package.
