### PR TITLE
fix(mic-osd): use active Python for daemon

### DIFF
--- a/lib/mic_osd/runner.py
+++ b/lib/mic_osd/runner.py
@@ -150,8 +150,9 @@ sys.exit(main())
             env['LD_PRELOAD'] = lib_path
 
         try:
+            python_cmd = sys.executable or 'python3'
             self._process = subprocess.Popen(
-                ['/usr/bin/python3', '-c', code],
+                [python_cmd, '-c', code],
                 env=env,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- start the mic_osd daemon with the current Python executable instead of a hard-coded system Python
- keep the daemon in the same environment as the main app so visualization dependencies resolve consistently

## Why
The main app can run from a virtual environment that has the audio and GTK dependencies needed by mic_osd. The daemon was still launched with a hard-coded system Python, so it could run with a different dependency set than the main app.

## Risk if not fixed
If the daemon starts outside the active app environment, mic_osd can miss runtime dependencies or load different package versions. In that state the overlay may appear, but the audio level signal can stay flat instead of reacting to microphone input, leaving recording without the expected waveform feedback.

## Test
- python3 -m py_compile lib/mic_osd/runner.py lib/mic_osd/main.py
- verified the service starts the mic_osd daemon with venv Python
