### PR TITLE
fix: add rpm fallback for ydotool version detection

### DIFF
--- a/lib/src/cli_commands.py
+++ b/lib/src/cli_commands.py
@@ -286,6 +286,22 @@ def _check_ydotool_version() -> tuple[bool, str, str]:
         except Exception:
             pass
 
+    # Try rpm (openSUSE/Fedora/RHEL)
+    if not version:
+        try:
+            result = subprocess.run(
+                ['rpm', '-q', 'ydotool'],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            # Output format: "ydotool-1.0.4-2.2.x86_64"
+            match = re.search(r'ydotool-(\d+\.\d+\.?\d*)', result.stdout)
+            if match:
+                version = match.group(1)
+        except Exception:
+            pass
+
     # Fallback: try --version (old ydotool 0.1.x supports this)
     if not version:
         try:


### PR DESCRIPTION
## Summary
Adds `rpm -q ydotool` as a version detection fallback for rpm-based distros (openSUSE, Fedora, RHEL).

Closes #169

## What changed
`lib/src/cli_commands.py` - inserted an `rpm -q` check between the existing `pacman` check and the `--version` fallback, following the same pattern.

## Testing
Verified on openSUSE Tumbleweed with ydotool 1.0.4:
`ok=True, version=1.0.4, msg=ydotool 1.0.4 (compatible)`