### PR TITLE
fix(paste): restore paste on non-Latin keyboard layouts (Thai, Russian, …) on GNOME

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -913,6 +913,15 @@ Quick way to fix it on Wayland (no arithmetic):
 
 Advanced (if you already know the Linux evdev keycode): set `paste_keycode` directly.
 
+> **Non-Latin layouts (Thai, Russian, Arabic, Greek, Hebrew, …):** `paste_keycode`
+> can't help here — there is no physical key that produces a `v` keysym, so the
+> Ctrl+V chord can never paste while that layout is active. On **GNOME/Mutter**,
+> hyprwhspr handles this automatically: it briefly switches the active input
+> source to a configured Latin layout (e.g. `us`) for the paste chord, then
+> restores your previous layout. Just keep a Latin source in
+> Settings → Keyboard → Input Sources. (The clipboard text itself is Unicode and
+> pastes verbatim regardless of layout.)
+
 ### Auto-submit
 
 Automatically press Enter after pasting.

--- a/lib/src/text_injector.py
+++ b/lib/src/text_injector.py
@@ -521,6 +521,63 @@ class TextInjector:
             print(f"ydotool type injection failed: {e}")
             return False
 
+    def _gnome_force_latin_layout(self):
+        """Temporarily switch the GNOME input source to a Latin (ASCII) layout so
+        the raw-keycode paste chord (Ctrl+V) resolves to keysym 'v'.
+
+        The clipboard chord is sent as physical keycodes via ydotool, and Mutter
+        translates them through the *active* XKB layout. On a non-Latin layout
+        (Thai, Russian, Arabic, Greek, Hebrew, …) KEY_V has no 'v' keysym at all,
+        so Ctrl+KEY_V never triggers paste and the dictated text silently fails to
+        land. (This is distinct from the `paste_keycode` workaround, which only
+        helps Latin layouts like Dvorak where 'v' merely moves to another key.)
+
+        Returns the previous input-source index to restore, or None when no switch
+        is needed/possible (not GNOME, no Latin source configured, already Latin).
+        """
+        if not self._is_gnome_wayland_session():
+            return None
+        try:
+            import ast
+            schema = 'org.gnome.desktop.input-sources'
+            srcs_raw = subprocess.run(['gsettings', 'get', schema, 'sources'],
+                                      capture_output=True, text=True, timeout=1).stdout.strip()
+            cur_raw = subprocess.run(['gsettings', 'get', schema, 'current'],
+                                     capture_output=True, text=True, timeout=1).stdout.strip()
+            cur_idx = int(cur_raw.split()[-1])
+            sources = ast.literal_eval(srcs_raw)  # e.g. [('xkb', 'us'), ('xkb', 'th')]
+            latin = {'us', 'gb', 'dvorak', 'colemak', 'workman', 'de', 'fr', 'es',
+                     'it', 'pt', 'latam', 'no', 'se', 'dk', 'fi'}
+            latin_idx = None
+            for i, (stype, name) in enumerate(sources):  # prefer plain 'us'
+                if stype == 'xkb' and name.split('+')[0] == 'us':
+                    latin_idx = i
+                    break
+            if latin_idx is None:
+                for i, (stype, name) in enumerate(sources):
+                    if stype == 'xkb' and name.split('+')[0] in latin:
+                        latin_idx = i
+                        break
+            if latin_idx is None or latin_idx == cur_idx:
+                return None
+            subprocess.run(['gsettings', 'set', schema, 'current', f'uint32 {latin_idx}'], timeout=1)
+            time.sleep(0.12)  # let gnome-shell apply the layout before the chord
+            return cur_idx
+        except Exception as e:
+            print(f"  paste layout switch skipped: {e}")
+            return None
+
+    def _gnome_restore_layout(self, prev_idx):
+        """Restore the input source saved by _gnome_force_latin_layout(). No-op
+        when prev_idx is None."""
+        if prev_idx is None:
+            return
+        try:
+            subprocess.run(['gsettings', 'set', 'org.gnome.desktop.input-sources',
+                            'current', f'uint32 {prev_idx}'], timeout=1)
+        except Exception:
+            pass
+
     def _save_clipboard(self) -> Optional[bytes]:
         """Save current clipboard contents. Returns raw bytes or None."""
         if shutil.which("wl-paste"):
@@ -854,7 +911,15 @@ class TextInjector:
             if not pasted and self.ydotool_available:
                 self._clear_stuck_modifiers()
                 time.sleep(0.02)
-                pasted = self._send_paste_keys_slow(paste_mode)
+                # Non-Latin layouts (Thai, Russian, …) remap KEY_V, so the raw-keycode
+                # Ctrl+V chord lands as the wrong keysym and paste silently fails. Force
+                # a Latin layout just for the chord, then restore — the clipboard text is
+                # Unicode and pastes correctly regardless of the active layout.
+                _prev_layout = self._gnome_force_latin_layout()
+                try:
+                    pasted = self._send_paste_keys_slow(paste_mode)
+                finally:
+                    self._gnome_restore_layout(_prev_layout)
 
             if not pasted and not self.wtype_available and not self.ydotool_available:
                 print("No key-injection tool available; text is on the clipboard.")


### PR DESCRIPTION
## Problem

On **GNOME/Mutter Wayland**, dictated text silently fails to paste when a **non-Latin keyboard layout** is active (Thai, Russian, Arabic, Greek, Hebrew, …).

The clipboard path copies the (correct, Unicode) transcript to the clipboard and then sends the paste chord with `ydotool key` — i.e. **physical keycodes** (`KEY_LEFTCTRL` + `KEY_V`). Mutter resolves those keycodes through the **active XKB layout**. Under a non-Latin layout, `KEY_V` produces a non-Latin keysym (e.g. Thai `ฟ`), so the app receives `Ctrl+ฟ` instead of `Ctrl+V` and never pastes. The clipboard ends up holding the right text, but nothing lands in the focused field.

The existing `paste_keycode` / `paste_keycode_wev` workaround does **not** help here: it only relocates the `v` *within a Latin layout* (Dvorak/bépo). On a non-Latin layout there is **no** physical key that yields a `v` keysym at all.

## Fix

Just before sending the chord on GNOME, briefly switch the active GNOME input source to a configured **Latin** layout (prefers `us`, falls back to other common Latin `xkb` sources), send `Ctrl+V`, then **restore the previous layout** in a `finally` block.

- The **clipboard content is Unicode**, so the pasted text is byte-for-byte correct in any language regardless of which layout was momentarily active.
- **No-op** when: not a GNOME/Mutter session, no Latin source is configured, or the active source is already Latin.
- Layout is **always restored** (saved index + `finally`), so the user is never left on the wrong layout.

```python
_prev_layout = self._gnome_force_latin_layout()
try:
    pasted = self._send_paste_keys_slow(paste_mode)
finally:
    self._gnome_restore_layout(_prev_layout)
```

## Testing

Verified the switch/restore round-trip on Ubuntu 24.04, GNOME 46, Wayland, with input sources `[('xkb','us'), ('xkb','th')]`:

```
active: th(1)  →  _gnome_force_latin_layout() → us(0), returns prev=1
                  _gnome_restore_layout(1)     → th(1)   ✓ restored
```

Before: dictating with the Thai layout active produced an empty paste (text stuck on clipboard).
After: text pastes correctly and the layout returns to Thai.

## Notes

- Scoped to the GNOME clipboard chord path; layer-shell compositors and the `wtype` path are untouched.
- There's a ~120 ms layout flip during the paste; happy to make the Latin-layout selection or the whole behaviour configurable if you'd prefer a `config.json` toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
