### PR TITLE
fix(install): optional visualizer deps shouldn't abort core install (PyGObject build failure on Ubuntu 24.04)

### DIFF
--- a/lib/src/backend_installer.py
+++ b/lib/src/backend_installer.py
@@ -1249,10 +1249,13 @@ def setup_python_venv(force_rebuild: bool = False, custom_python: Optional[str] 
     if not pip_bin.exists():
         log_error(f"pip not found in venv at {VENV_DIR}")
         raise FileNotFoundError(f"pip not found in venv")
-    
+
     # Upgrade pip and wheel (mise-free env applied automatically via run_command)
     run_command([str(pip_bin), 'install', '--upgrade', 'pip', 'wheel'], check=True)
-    
+
+    # Optional visualizer GUI deps — best-effort, never fatal (see helper docstring).
+    install_visualizer_deps(pip_bin)
+
     return pip_bin
 
 
@@ -1266,6 +1269,34 @@ def _should_skip_pygobject() -> bool:
         log_info("PyGObject already available (system package), skipping pip install")
         return True
     except ImportError:
+        return False
+
+
+def install_visualizer_deps(pip_bin) -> bool:
+    """Best-effort install of the optional mic-osd visualizer GUI deps.
+
+    These GUI bindings (PyGObject, pycairo) build against system libraries and can
+    fail on some distros — e.g. PyGObject >= 3.50 needs girepository-2.0, which is
+    not packaged on Ubuntu 24.04. They live in requirements-visualizer.txt (not the
+    core requirements.txt) and are installed here separately and non-fatally, so a
+    GUI build failure only disables the animated overlay and never blocks the core
+    dictation runtime. Skipped when PyGObject is already importable from system
+    packages (the venv uses --system-site-packages).
+    """
+    if _should_skip_pygobject():
+        return True
+    req = Path(HYPRWHSPR_ROOT) / 'requirements-visualizer.txt'
+    if not req.exists():
+        return True
+    log_info("Installing optional mic-osd visualizer deps (best-effort)…")
+    try:
+        run_command([str(pip_bin), 'install', '-r', str(req)], check=True)
+        return True
+    except subprocess.CalledProcessError as e:
+        log_warning(
+            "mic-osd visualizer deps could not be built — the animated overlay "
+            f"will be unavailable (core dictation is unaffected): {e}"
+        )
         return False
 
 

--- a/requirements-visualizer.txt
+++ b/requirements-visualizer.txt
@@ -1,0 +1,12 @@
+# Optional dependencies for the mic-osd visualizer (animated overlay).
+#
+# These are GUI bindings that build against system libraries (gobject-introspection,
+# cairo) and can fail to build on some distros — e.g. PyGObject >= 3.50 needs
+# girepository-2.0, which is not packaged on Ubuntu 24.04. They are therefore
+# installed best-effort and separately from requirements.txt: a failure here only
+# disables the visualizer overlay, never the core dictation runtime.
+#
+# Skipped entirely when PyGObject is already importable from system packages
+# (the venv is created with --system-site-packages).
+PyGObject>=3.50.0
+pycairo>=1.25.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,9 +21,10 @@ dbus-python>=1.3.0
 # CLI formatting and logging
 rich>=14.0.0
 
-# Mic-osd visualization (requires python-gobject/python-cairo system packages)
-PyGObject>=3.50.0
-pycairo>=1.25.0
-
 # ElevenLabs integration
 elevenlabs>=2.40.0
+
+# NOTE: the mic-osd visualizer's GUI deps (PyGObject, pycairo) live in
+# requirements-visualizer.txt and are installed best-effort, so a GUI build
+# failure (e.g. missing girepository-2.0 on Ubuntu 24.04) can never abort the
+# install of the core runtime deps above.


### PR DESCRIPTION
## Problem

On a fresh install with a **cloud backend** (Realtime WS / REST API), the service fails to start with:

```
ModuleNotFoundError: No module named 'sounddevice'
```

even though `sounddevice` is the first line of `requirements.txt`.

Root cause: the **mic-osd visualizer GUI deps** (`PyGObject`, `pycairo`) live in `requirements.txt` next to the core runtime deps. On distros where they fail to build, `pip install -r requirements.txt` aborts the **whole** batch — so packages that pip hadn't installed yet (including the core ones) never land. The most common trigger is **Ubuntu 24.04**: `PyGObject >= 3.50` requires `girepository-2.0`, which isn't packaged there, so the meson build dies:

```
ERROR: Dependency 'girepository-2.0' is required but not found.
...
[ERROR] Failed to install base dependencies
```

The whisper backends dodge this via `_should_skip_pygobject()` + `_filter_requirements()`, but the **cloud-backend paths** (`realtime-ws`, `rest-api`, `faster-whisper`, `cohere-transcribe`) install the full `requirements.txt` directly with no filtering, so they take the full hit and leave the venv without `sounddevice` / `elevenlabs` / etc.

## Fix

Treat the visualizer GUI bindings as what they are — **optional**:

- Move `PyGObject` / `pycairo` out of `requirements.txt` into a new **`requirements-visualizer.txt`**.
- Install them **best-effort** in `setup_python_venv()` via a new `install_visualizer_deps()`:
  - skipped when PyGObject is already importable from system packages (the venv uses `--system-site-packages`),
  - on build failure it logs a warning and continues — the overlay is disabled, the core runtime is untouched,
  - no-ops if the file is absent (packaged layouts).

Net effect: `pip install -r requirements.txt` only ever installs deps that reliably wheel/build, so it can no longer abort core install. The visualizer still installs whenever the toolchain supports it.

## Why not just keep filtering per-path?

The filtering was only wired into the whisper paths; the cloud paths regressed because they didn't replicate it. Splitting the optional deps into their own file fixes **every** path at once (and any future path), instead of repeating the skip/filter dance in each branch.

## Testing

- `python -m py_compile lib/src/backend_installer.py` — clean.
- Reproduced the original failure on Ubuntu 24.04 + GNOME 46 with the `realtime-ws` (ElevenLabs) backend (girepository-2.0 build abort → missing `sounddevice`).
- With the change, core deps install cleanly and the service reaches `[READY]`; the visualizer deps are attempted separately and their failure is a warning, not a hard stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
