### PR TITLE
support keyboard hotplug without listing device names

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1035,11 +1035,19 @@ Device name takes priority if both are set. Use `hyprwhspr keyboard list` to see
 
 ### Keyboard hotplug (docks, Bluetooth)
 
-By default, hyprwhspr only discovers keyboards at startup. If you dock a laptop, reconnect a Bluetooth/USB keyboard, or resume from suspend, the service won't re-attach that keyboard until it is restarted — so the shortcut silently stops working on it.
+By default (`keyboard_hotplug: true`) hyprwhspr watches for keyboards plugged in after startup and attaches them automatically.  This is controlled by the `keyboard_hotplug` flag:
 
-The fix is to set a `keyboard_device_names` allowlist. Listed devices are attached at startup **and** automatically re-attached when they reappear later, which keeps the shortcut alive across disconnect/reconnect, docking and suspend. Devices not on the list (mice, media controllers) are ignored even if they advertise keyboard-like capabilities.
+```jsonc
+{
+  "keyboard_hotplug": true   // default; set false for startup-only discovery
+}
+```
 
-**Recommended — interactive configurator:**
+Set it to `false` if you want hyprwhspr to only ever use keyboards present when the service starts.
+
+**Restricting which keyboards are used (optional):** setting a `keyboard_device_names` allowlist limits attachment — at startup *and* on hot-plug — to just the listed devices. Use it if auto-discovery picks up a device you don't want grabbed, or to pin behavior to a known set of keyboards. Leave it unset to keep the default "attach any keyboard" behavior.
+
+**Interactive configurator (to set the optional allowlist):**
 
 ```bash
 hyprwhspr keyboard configure

--- a/lib/main.py
+++ b/lib/main.py
@@ -278,6 +278,7 @@ class hyprwhsprApp:
             selected_device_path = self.config.get_setting("selected_device_path", None)
             selected_device_name = self.config.get_setting("selected_device_name", None)
             keyboard_device_names = self.config.get_setting("keyboard_device_names", None)
+            keyboard_hotplug = self.config.get_setting("keyboard_hotplug", True)
 
             # Register callbacks based on recording mode
             # Validate recording_mode and only register release callback for modes that need it
@@ -291,6 +292,7 @@ class hyprwhsprApp:
                     device_name=selected_device_name,
                     grab_keys=grab_keys,
                     keyboard_device_names=keyboard_device_names,
+                    keyboard_hotplug=keyboard_hotplug,
                 )
             elif recording_mode in ('push_to_talk', 'auto'):
                 # Push-to-talk and auto modes: register both press and release callbacks
@@ -302,6 +304,7 @@ class hyprwhsprApp:
                     device_name=selected_device_name,
                     grab_keys=grab_keys,
                     keyboard_device_names=keyboard_device_names,
+                    keyboard_hotplug=keyboard_hotplug,
                 )
             elif recording_mode == 'long_form':
                 # Long-form mode: primary key toggles recording/paused, no release callback
@@ -313,6 +316,7 @@ class hyprwhsprApp:
                     device_name=selected_device_name,
                     grab_keys=grab_keys,
                     keyboard_device_names=keyboard_device_names,
+                    keyboard_hotplug=keyboard_hotplug,
                 )
                 # Initialize segment manager for long-form mode
                 max_size_mb = self.config.get_setting('long_form_temp_limit_mb', 500)
@@ -331,6 +335,7 @@ class hyprwhsprApp:
                     device_name=selected_device_name,
                     grab_keys=grab_keys,
                     keyboard_device_names=keyboard_device_names,
+                    keyboard_hotplug=keyboard_hotplug,
                 )
         except Exception as e:
             print(f"[ERROR] Failed to initialize global shortcuts: {e}", flush=True)
@@ -352,6 +357,7 @@ class hyprwhsprApp:
                             device_name=selected_device_name,
                             grab_keys=grab_keys,
                             keyboard_device_names=keyboard_device_names,
+                            keyboard_hotplug=keyboard_hotplug,
                         )
                     elif recording_mode in ('push_to_talk', 'auto'):
                         self.secondary_shortcuts = GlobalShortcuts(
@@ -362,6 +368,7 @@ class hyprwhsprApp:
                             device_name=selected_device_name,
                             grab_keys=grab_keys,
                             keyboard_device_names=keyboard_device_names,
+                            keyboard_hotplug=keyboard_hotplug,
                         )
                     else:
                         # Invalid mode: default to toggle behavior
@@ -373,6 +380,7 @@ class hyprwhsprApp:
                             device_name=selected_device_name,
                             grab_keys=grab_keys,
                             keyboard_device_names=keyboard_device_names,
+                            keyboard_hotplug=keyboard_hotplug,
                         )
                     
                     # Start the secondary shortcuts
@@ -399,6 +407,7 @@ class hyprwhsprApp:
                     device_name=selected_device_name,
                     grab_keys=grab_keys,
                     keyboard_device_names=keyboard_device_names,
+                    keyboard_hotplug=keyboard_hotplug,
                 )
                 if self._cancel_shortcuts.start():
                     print(f"[INFO] Cancel shortcut registered: {cancel_shortcut_key}", flush=True)
@@ -422,6 +431,7 @@ class hyprwhsprApp:
                         device_name=selected_device_name,
                         grab_keys=grab_keys,
                         keyboard_device_names=keyboard_device_names,
+                        keyboard_hotplug=keyboard_hotplug,
                     )
                     if self._longform_submit_shortcuts.start():
                         print(f"[INFO] Long-form submit shortcut registered: {submit_shortcut_key}", flush=True)

--- a/lib/src/config_manager.py
+++ b/lib/src/config_manager.py
@@ -56,13 +56,15 @@ class ConfigManager:
             'use_hypr_bindings': False,  # Use Hyprland compositor bindings instead of evdev (disables GlobalShortcuts)
             'selected_device_path': None,  # Specific keyboard device path (e.g., '/dev/input/event3')
             'selected_device_name': None,  # Specific keyboard device name (e.g., 'USB Keyboard') - takes priority over path if both set
-            # Optional allowlist of keyboard device names. Two effects:
-            # (1) restricts which devices are grabbed at startup — mice/media
-            #     controllers that advertise keyboard-shaped capabilities are
-            #     skipped; (2) enables pyudev-based hotplug detection for the
-            #     listed devices (docked keyboards work without service restart).
-            # Ignored when selected_device_name / selected_device_path is set.
-            # Null (default) = legacy behavior: startup-only discovery, no filter.
+            # Watch for keyboards plugged in after startup (pyudev) and attach
+            # them live, so docked/Bluetooth/USB keyboards work without a service
+            # restart. True (default) enables this for any keyboard that passes
+            # the same checks as startup discovery.
+            'keyboard_hotplug': True,
+            # Optional allowlist of keyboard device names. Restricts which
+            # devices are grabbed at startup AND on hotplug — mice/media
+            # controllers that advertise keyboard-shaped capabilities are
+            # skipped.  Null (default) = no filter.
             'keyboard_device_names': None,
             # Audio device persistence (for reliable device matching across reboots)
             'audio_device_id': None,        # PortAudio device index (can change on reboot)

--- a/lib/src/global_shortcuts.py
+++ b/lib/src/global_shortcuts.py
@@ -217,7 +217,7 @@ class GlobalShortcuts:
 
     _warned_allowlist_misses: Set[tuple[str, ...]] = set()
 
-    def __init__(self, primary_key: str = '<f12>', callback: Optional[Callable] = None, release_callback: Optional[Callable] = None, device_path: Optional[str] = None, device_name: Optional[str] = None, grab_keys: bool = True, keyboard_device_names: Optional[List[str]] = None):
+    def __init__(self, primary_key: str = '<f12>', callback: Optional[Callable] = None, release_callback: Optional[Callable] = None, device_path: Optional[str] = None, device_name: Optional[str] = None, grab_keys: bool = True, keyboard_device_names: Optional[List[str]] = None, keyboard_hotplug: bool = True):
         self.primary_key = primary_key
         self.callback = callback
         self.selected_device_path = device_path
@@ -228,9 +228,10 @@ class GlobalShortcuts:
         # Ignored when selected_device_name/path is set (those are single-device overrides).
         self.keyboard_device_names = ([n.lower() for n in keyboard_device_names]
                                        if keyboard_device_names else None)
+        self.keyboard_hotplug = keyboard_hotplug
 
         # Hotplug monitor: detects keyboards plugged in after startup (e.g. docking).
-        # Started in start(); stopped in stop(). Gated on a non-nil allowlist.
+        # Started in start(); stopped in stop().
         self.keyboard_monitor: Optional[KeyboardMonitor] = None
 
         # Device and event handling
@@ -945,16 +946,9 @@ class GlobalShortcuts:
     def _start_hotplug_monitor(self):
         """Start pyudev-based hotplug monitor for input devices.
 
-        Gated on a non-nil `keyboard_device_names` allowlist: by listing
-        real keyboards the user has consented to runtime device discovery
-        for those devices. Without an allowlist, aggressive hotplug can
-        grab mice and media controllers whose EV_KEY capabilities look
-        keyboard-shaped (e.g. Logitech multi-device mice), so we keep the
-        legacy startup-only discovery path.
-
         Non-fatal if pyudev is unavailable or the monitor fails to start.
         """
-        if not self.keyboard_device_names:
+        if not self.keyboard_hotplug:
             return
         if not PYUDEV_AVAILABLE:
             print("[HOTPLUG] pyudev not available; keyboards plugged in after "

--- a/share/config.schema.json
+++ b/share/config.schema.json
@@ -56,11 +56,16 @@
       "default": null,
       "description": "Specific keyboard device name (e.g., 'USB Keyboard'). Takes priority over path if both set."
     },
+    "keyboard_hotplug": {
+      "type": "boolean",
+      "default": true,
+      "description": "Watch for keyboards plugged in after startup (pyudev) and attach them live, so docked/Bluetooth/USB keyboards work without restarting the service. True (default) enables this for any keyboard that passes the same checks as startup discovery (must emit every shortcut key). Set false to restore startup-only discovery."
+    },
     "keyboard_device_names": {
       "type": ["array", "null"],
       "items": { "type": "string" },
       "default": null,
-      "description": "Optional allowlist of keyboard device names. When set: (1) only listed devices are grabbed at startup; (2) pyudev-based hotplug detection is enabled so listed devices plugged in later (e.g. docking a laptop) are attached without restarting the service. Ignored if selected_device_name or selected_device_path is set. Null (default) = legacy startup-only discovery."
+      "description": "Optional allowlist of keyboard device names. When set, only listed devices are grabbed at startup AND on hotplug. Ignored if selected_device_name or selected_device_path is set. Null (default) = no name filter."
     },
     "audio_device_id": {
       "type": ["integer", "null"],


### PR DESCRIPTION
This change makes it possible to configure hyprwhspr on a laptop to accept shortcut keys on all keyboard devices, regardless of whether they are plugged in at service startup time or later (e.g., via dock hotplug).

Before this change, hyprwhspr only supported two possible regimes: either accept any keyboard (but only at service startup time), or accept keyboards plugged in later, like dock hotplug (but require the user to explicitly list the names of every keyboard device that should be used). The latter option doesn't work well when the laptop is plugged into many different docks over time, since every new dock requires potentially updating the config file to add yet another keyboard name.