### PR TITLE
fix(mic-osd): resolve gtk4-layer-shell on Debian/Ubuntu multiarch

### DIFF
--- a/lib/mic_osd/runner.py
+++ b/lib/mic_osd/runner.py
@@ -59,6 +59,7 @@ class MicOSDRunner:
         for pattern in [
             '/usr/lib64/libgtk4-layer-shell.so*',
             '/usr/lib/libgtk4-layer-shell.so*',
+            '/usr/lib/*/libgtk4-layer-shell.so*',
             '/usr/local/lib64/libgtk4-layer-shell.so*',
             '/usr/local/lib/libgtk4-layer-shell.so*',
         ]:
@@ -195,6 +196,7 @@ sys.exit(main())
         for pattern in [
             '/usr/lib64/libgtk4-layer-shell.so*',
             '/usr/lib/libgtk4-layer-shell.so*',
+            '/usr/lib/*/libgtk4-layer-shell.so*',
             '/usr/local/lib64/libgtk4-layer-shell.so*',
             '/usr/local/lib/libgtk4-layer-shell.so*',
         ]:


### PR DESCRIPTION
## Problem
On Debian/Ubuntu, `gtk4-layer-shell` installs to the multiarch directory (e.g. `/usr/lib/x86_64-linux-gnu/`). The `LD_PRELOAD` `.so` search in `lib/mic_osd/runner.py` only covered `/usr/lib64` (Fedora/RHEL, added in #145), `/usr/lib`, and `/usr/local/lib{,64}` — not multiarch. As a result `MicOSDRunner.layer_shell_active()` returned `False`, and the mic-OSD overlay **silently fell back to desktop notifications** even when `gtk4-layer-shell` was installed and the compositor advertised layer-shell support.

This is the same class of bug as #145 (Fedora aarch64 `/usr/lib64`), one distro over.

## Fix
Add `'/usr/lib/*/libgtk4-layer-shell.so*'` to **both** glob lists in `runner.py` (the `_layer_shell_ld_preload` staticmethod and the `_ensure_daemon` block). The wildcard matches any Debian multiarch triplet (`x86_64-linux-gnu`, `aarch64-linux-gnu`, `arm-linux-gnueabihf`, …) without hardcoding each arch.

```diff
         for pattern in [
             '/usr/lib64/libgtk4-layer-shell.so*',
             '/usr/lib/libgtk4-layer-shell.so*',
+            '/usr/lib/*/libgtk4-layer-shell.so*',
             '/usr/local/lib64/libgtk4-layer-shell.so*',
             '/usr/local/lib/libgtk4-layer-shell.so*',
         ]:
```

## Verification
On Linux Mint 22 (Ubuntu 24.04 base) / KDE KWin 5.27 (Wayland) / gtk4-layer-shell 1.3.0:
- With the multiarch lib installed, `MicOSDRunner.layer_shell_active()` goes `False → True`.
- Reverting the change reproduces the empty-result bug (`_layer_shell_ld_preload()` → `''`).
- The OSD daemon spawns and renders end-to-end with no symlink/workaround in place.
- `tests/test_mic_osd_runner.py` — 16/16 pass.

Follow-up to #145.