### PR TITLE
feat: auto-stop recording on silence (silence_timeout) — refs #201

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -81,6 +81,22 @@ Hybrid tap/hold - automatically detects your intent:
 - **Tap** (< 400ms) - Toggle behavior: tap to start recording, tap again to stop
 - **Hold** (>= 400ms) - Push-to-talk behavior: hold to record, release to stop
 
+### Auto-stop on silence
+
+In **toggle** and **auto** modes, `silence_timeout` automatically stops recording (transcribe + paste) after a period of silence — press once, speak, and it finalizes itself when you go quiet:
+
+```jsonc
+{
+    "recording_mode": "toggle",
+    "silence_timeout": 2.5  // Auto-stop after 2.5s of silence. 0 (default) = disabled.
+}
+```
+
+- Default is `0` (disabled) - existing behavior is unchanged.
+- The timer **only arms after speech is detected**, so it won't fire while you're still composing your first sentence.
+- The silence threshold auto-calibrates from your mic's noise floor (shares `continuous_silence_threshold`).
+- Manual stop still works at any time; the stop beep signals the auto-stop. This is purely additive.
+
 ### Continuous mode
 
 Press to start, speak naturally, and when you pause for a couple seconds the text is automatically transcribed and pasted. Press again to stop:

--- a/lib/main.py
+++ b/lib/main.py
@@ -752,7 +752,7 @@ class hyprwhsprApp:
         value = self.config.get_setting(key, default)
         try:
             value = float(value)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             return default
         return value if math.isfinite(value) else default
 
@@ -848,16 +848,19 @@ class hyprwhsprApp:
                         elif armed:
                             silent_count += 1
                             if silent_count >= samples_needed:
-                                print(f"[AUTOSTOP] {silence_timeout:.1f}s of silence - stopping recording", flush=True)
                                 stop_event.set()
-                                # Deregister ourselves before handing off to _stop_recording()
-                                # (which also tears down the monitor generically) so a
-                                # concurrent new session's monitor can't be clobbered by us.
+                                # Deregister ourselves before handing off to _stop_recording().
+                                # If a newer generation already replaced us here, our session
+                                # already ended some other way - don't stop whatever is
+                                # recording now, it isn't ours.
                                 with self._autostop_lock:
-                                    if self._autostop_silence_thread is thread:
+                                    still_current = self._autostop_silence_thread is thread
+                                    if still_current:
                                         self._autostop_silence_thread = None
                                         self._autostop_silence_stop = None
-                                self._stop_recording()   # plays the stop beep; transcribes + pastes
+                                if still_current:
+                                    print(f"[AUTOSTOP] {silence_timeout:.1f}s of silence - stopping recording", flush=True)
+                                    self._stop_recording()   # plays the stop beep; transcribes + pastes
                                 return
                         stop_event.wait(self._POLL_INTERVAL)
                 except Exception as e:
@@ -873,7 +876,10 @@ class hyprwhsprApp:
             self._autostop_teardown_locked()
 
     def _autostop_teardown_locked(self):
-        """Tear down the currently-registered autostop monitor. Caller must hold `_autostop_lock`."""
+        """Tear down whatever autostop monitor is currently registered. Caller must hold `_autostop_lock`.
+
+        No generation check here (unlike the monitor's self-stop path) - accepted edge case.
+        """
         stop_event = self._autostop_silence_stop
         thread = self._autostop_silence_thread
         if stop_event is not None:

--- a/lib/main.py
+++ b/lib/main.py
@@ -191,6 +191,10 @@ class hyprwhsprApp:
         self._continuous_transcription_done.set()  # no transcription in flight
         self._continuous_cancelled = False  # set on cancel to suppress in-flight injection
 
+        # Auto-stop-on-silence state (toggle/auto modes)
+        self._autostop_silence_thread = None
+        self._autostop_silence_stop = threading.Event()
+
         # Long-form recording mode state
         self._longform_state = 'IDLE'  # IDLE, RECORDING, PAUSED, PROCESSING, ERROR
         self._longform_language_override = None  # Language override for long-form session
@@ -646,6 +650,8 @@ class hyprwhsprApp:
                 self._start_recording(language_override=language_override)
                 if recording_mode == 'continuous':
                     self._continuous_start_silence_monitor()
+                elif recording_mode == 'toggle':
+                    self._autostop_start_silence_monitor()
         elif recording_mode == 'push_to_talk':
             # Push-to-talk mode: only start recording on key press
             if not self.is_recording:
@@ -674,6 +680,7 @@ class hyprwhsprApp:
             # Call _start_recording() outside the lock to avoid blocking release callback
             if should_start:
                 self._start_recording(language_override=language_override)
+                self._autostop_start_silence_monitor()
         else:
             # Invalid mode, default to toggle behavior
             if self.is_recording:
@@ -783,6 +790,71 @@ class hyprwhsprApp:
         if self._continuous_silence_thread and self._continuous_silence_thread.is_alive():
             self._continuous_silence_thread.join(timeout=0.5)
         self._continuous_silence_thread = None
+
+    def _autostop_start_silence_monitor(self):
+        """Auto-stop recording after `silence_timeout` seconds of silence (toggle/auto modes).
+
+        Arms only after speech has been detected, so it can't fire while the user is
+        still composing their first sentence. The silence threshold auto-calibrates from
+        the noise floor (same approach as continuous mode). No-op when silence_timeout <= 0.
+        """
+        self._autostop_stop_silence_monitor()
+
+        silence_timeout = self.config.get_setting('silence_timeout', 0)
+        try:
+            silence_timeout = float(silence_timeout)
+        except (TypeError, ValueError):
+            silence_timeout = 0
+        if silence_timeout <= 0:
+            return  # feature disabled (default)
+
+        self._autostop_silence_stop.clear()
+        samples_needed = max(1, int(silence_timeout / self._POLL_INTERVAL))
+        configured_threshold = self.config.get_setting('continuous_silence_threshold', 0)
+
+        def monitor():
+            try:
+                threshold = configured_threshold
+                if threshold <= 0:
+                    # Sample the noise floor over ~0.6s to auto-calibrate
+                    samples = []
+                    for _ in range(6):
+                        self._autostop_silence_stop.wait(0.1)
+                        if self._autostop_silence_stop.is_set() or not self.is_recording:
+                            return
+                        samples.append(self.audio_capture.rolling_avg_level)
+                    noise_floor = min(samples)
+                    threshold = max(noise_floor * 2, 2e-4)
+
+                armed = False          # don't count silence until speech has been heard
+                silent_count = 0
+                while self.is_recording and not self._autostop_silence_stop.is_set():
+                    level = self.audio_capture.rolling_avg_level
+                    if level >= threshold:
+                        armed = True
+                        silent_count = 0
+                    elif armed:
+                        silent_count += 1
+                        if silent_count >= samples_needed:
+                            print(f"[AUTOSTOP] {silence_timeout:.1f}s of silence - stopping recording", flush=True)
+                            self._autostop_silence_stop.set()
+                            self._stop_recording()   # plays the stop beep; transcribes + pastes
+                            return
+                    self._autostop_silence_stop.wait(self._POLL_INTERVAL)
+            except Exception as e:
+                print(f"[AUTOSTOP] Silence monitor error: {e}", flush=True)
+
+        self._autostop_silence_thread = threading.Thread(target=monitor, daemon=True)
+        self._autostop_silence_thread.start()
+
+    def _autostop_stop_silence_monitor(self):
+        """Stop the auto-stop silence monitor (safe to call from anywhere, incl. the monitor)."""
+        self._autostop_silence_stop.set()
+        thread = self._autostop_silence_thread
+        # Avoid self-join deadlock when the monitor thread is the one triggering the stop
+        if thread and thread.is_alive() and threading.current_thread() is not thread:
+            thread.join(timeout=0.5)
+        self._autostop_silence_thread = None
 
     def _continuous_stop_and_wait(self):
         """Stop the silence monitor and wait for any in-progress transcription"""
@@ -1475,6 +1547,9 @@ class hyprwhsprApp:
 
         print("Recording stopped", flush=True)
 
+        # Tear down the auto-stop silence monitor if it was running (toggle/auto modes)
+        self._autostop_stop_silence_monitor()
+
         try:
             self._clear_mic_osd_preview_text()
 
@@ -2045,6 +2120,8 @@ class hyprwhsprApp:
                         self._start_recording(language_override=language_param)
                         if recording_mode == "continuous":
                             self._continuous_start_silence_monitor()
+                        elif recording_mode in ("toggle", "auto"):
+                            self._autostop_start_silence_monitor()
                     else:
                         print("[CONTROL] Recording already in progress, ignoring start request", flush=True)
                 elif action == "stop":

--- a/lib/main.py
+++ b/lib/main.py
@@ -5,6 +5,7 @@ hyprwhspr - stt
 
 import sys
 import time
+import math
 import threading
 import os
 import socket
@@ -191,9 +192,11 @@ class hyprwhsprApp:
         self._continuous_transcription_done.set()  # no transcription in flight
         self._continuous_cancelled = False  # set on cancel to suppress in-flight injection
 
-        # Auto-stop-on-silence state (toggle/auto modes)
+        # Auto-stop-on-silence state (toggle/auto modes). The stop Event is created fresh
+        # per session (not reused) so a stale monitor generation can never signal a newer one.
         self._autostop_silence_thread = None
-        self._autostop_silence_stop = threading.Event()
+        self._autostop_silence_stop = None
+        self._autostop_lock = threading.Lock()  # guards thread/event bookkeeping across threads
 
         # Long-form recording mode state
         self._longform_state = 'IDLE'  # IDLE, RECORDING, PAUSED, PROCESSING, ERROR
@@ -744,15 +747,35 @@ class hyprwhsprApp:
     # Continuous mode: auto-paste on speech pause
     _POLL_INTERVAL = 0.1  # seconds between silence checks
 
+    def _get_float_setting(self, key, default=0.0):
+        """Coerce a config value to float; falls back to `default` if missing, invalid, or non-finite (NaN/Infinity)."""
+        value = self.config.get_setting(key, default)
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            return default
+        return value if math.isfinite(value) else default
+
+    def _calibrate_noise_floor(self, stop_event):
+        """Sample the mic's noise floor over ~0.6s. Returns None if stopped/recording ended early."""
+        samples = []
+        for _ in range(6):
+            stop_event.wait(0.1)
+            if stop_event.is_set() or not self.is_recording:
+                return None
+            samples.append(self.audio_capture.rolling_avg_level)
+        noise_floor = min(samples)
+        return max(noise_floor * 2, 2e-4)
+
     def _continuous_start_silence_monitor(self):
         """Start monitoring for silence to trigger auto-paste in continuous mode"""
         self._continuous_cancelled = False
         self._continuous_stop_silence_monitor()
         self._continuous_silence_stop.clear()
 
-        silence_seconds = self.config.get_setting('continuous_silence_seconds', 2.0)
-        configured_threshold = self.config.get_setting('continuous_silence_threshold', 0)
-        samples_needed = int(silence_seconds / self._POLL_INTERVAL)
+        silence_seconds = self._get_float_setting('continuous_silence_seconds', 2.0)
+        configured_threshold = self._get_float_setting('continuous_silence_threshold', 0)
+        samples_needed = max(1, int(silence_seconds / self._POLL_INTERVAL))
 
         def monitor():
             silent_count = 0
@@ -760,17 +783,10 @@ class hyprwhsprApp:
                 # Auto-calibrate threshold from noise floor if not manually configured
                 threshold = configured_threshold
                 if threshold <= 0:
-                    # Sample level 6 times over 0.6s; use minimum to get noise floor
-                    # even if the user starts speaking immediately after pressing record
-                    samples = []
-                    for _ in range(6):
-                        self._continuous_silence_stop.wait(0.1)
-                        if self._continuous_silence_stop.is_set() or not self.is_recording:
-                            return
-                        samples.append(self.audio_capture.rolling_avg_level)
-                    noise_floor = min(samples)
-                    threshold = max(noise_floor * 2, 2e-4)
-                    print(f"[CONTINUOUS] Auto-calibrated threshold={threshold:.5f} (noise floor={noise_floor:.5f})", flush=True)
+                    threshold = self._calibrate_noise_floor(self._continuous_silence_stop)
+                    if threshold is None:
+                        return
+                    print(f"[CONTINUOUS] Auto-calibrated threshold={threshold:.5f}", flush=True)
 
                 while self.is_recording and not self._continuous_silence_stop.is_set():
                     raw_level = self.audio_capture.rolling_avg_level
@@ -802,67 +818,71 @@ class hyprwhsprApp:
         still composing their first sentence. The silence threshold auto-calibrates from
         the noise floor (same approach as continuous mode). No-op when silence_timeout <= 0.
         """
-        self._autostop_stop_silence_monitor()
+        silence_timeout = self._get_float_setting('silence_timeout', 0)
+        configured_threshold = self._get_float_setting('continuous_silence_threshold', 0)
 
-        silence_timeout = self.config.get_setting('silence_timeout', 0)
-        try:
-            silence_timeout = float(silence_timeout)
-        except (TypeError, ValueError):
-            silence_timeout = 0
-        if silence_timeout <= 0:
-            return  # feature disabled (default)
+        with self._autostop_lock:
+            self._autostop_teardown_locked()
+            if silence_timeout <= 0:
+                return  # feature disabled (default)
 
-        self._autostop_silence_stop.clear()
-        samples_needed = max(1, int(silence_timeout / self._POLL_INTERVAL))
-        configured_threshold = self.config.get_setting('continuous_silence_threshold', 0)
-        try:
-            configured_threshold = float(configured_threshold)
-        except (TypeError, ValueError):
-            configured_threshold = 0  # unset/null in config -> auto-calibrate
+            stop_event = threading.Event()
+            samples_needed = max(1, int(silence_timeout / self._POLL_INTERVAL))
 
-        def monitor():
-            try:
-                threshold = configured_threshold
-                if threshold <= 0:
-                    # Sample the noise floor over ~0.6s to auto-calibrate
-                    samples = []
-                    for _ in range(6):
-                        self._autostop_silence_stop.wait(0.1)
-                        if self._autostop_silence_stop.is_set() or not self.is_recording:
+            def monitor():
+                thread = threading.current_thread()
+                try:
+                    threshold = configured_threshold
+                    if threshold <= 0:
+                        threshold = self._calibrate_noise_floor(stop_event)
+                        if threshold is None:
                             return
-                        samples.append(self.audio_capture.rolling_avg_level)
-                    noise_floor = min(samples)
-                    threshold = max(noise_floor * 2, 2e-4)
 
-                armed = False          # don't count silence until speech has been heard
-                silent_count = 0
-                while self.is_recording and not self._autostop_silence_stop.is_set():
-                    level = self.audio_capture.rolling_avg_level
-                    if level >= threshold:
-                        armed = True
-                        silent_count = 0
-                    elif armed:
-                        silent_count += 1
-                        if silent_count >= samples_needed:
-                            print(f"[AUTOSTOP] {silence_timeout:.1f}s of silence - stopping recording", flush=True)
-                            self._autostop_silence_stop.set()
-                            self._stop_recording()   # plays the stop beep; transcribes + pastes
-                            return
-                    self._autostop_silence_stop.wait(self._POLL_INTERVAL)
-            except Exception as e:
-                print(f"[AUTOSTOP] Silence monitor error: {e}", flush=True)
+                    armed = False          # don't count silence until speech has been heard
+                    silent_count = 0
+                    while self.is_recording and not stop_event.is_set():
+                        level = self.audio_capture.rolling_avg_level
+                        if level >= threshold:
+                            armed = True
+                            silent_count = 0
+                        elif armed:
+                            silent_count += 1
+                            if silent_count >= samples_needed:
+                                print(f"[AUTOSTOP] {silence_timeout:.1f}s of silence - stopping recording", flush=True)
+                                stop_event.set()
+                                # Deregister ourselves before handing off to _stop_recording()
+                                # (which also tears down the monitor generically) so a
+                                # concurrent new session's monitor can't be clobbered by us.
+                                with self._autostop_lock:
+                                    if self._autostop_silence_thread is thread:
+                                        self._autostop_silence_thread = None
+                                        self._autostop_silence_stop = None
+                                self._stop_recording()   # plays the stop beep; transcribes + pastes
+                                return
+                        stop_event.wait(self._POLL_INTERVAL)
+                except Exception as e:
+                    print(f"[AUTOSTOP] Silence monitor error: {e}", flush=True)
 
-        self._autostop_silence_thread = threading.Thread(target=monitor, daemon=True)
-        self._autostop_silence_thread.start()
+            self._autostop_silence_thread = threading.Thread(target=monitor, daemon=True)
+            self._autostop_silence_stop = stop_event
+            self._autostop_silence_thread.start()
 
     def _autostop_stop_silence_monitor(self):
         """Stop the auto-stop silence monitor (safe to call from anywhere, incl. the monitor)."""
-        self._autostop_silence_stop.set()
+        with self._autostop_lock:
+            self._autostop_teardown_locked()
+
+    def _autostop_teardown_locked(self):
+        """Tear down the currently-registered autostop monitor. Caller must hold `_autostop_lock`."""
+        stop_event = self._autostop_silence_stop
         thread = self._autostop_silence_thread
+        if stop_event is not None:
+            stop_event.set()
         # Avoid self-join deadlock when the monitor thread is the one triggering the stop
         if thread and thread.is_alive() and threading.current_thread() is not thread:
             thread.join(timeout=0.5)
         self._autostop_silence_thread = None
+        self._autostop_silence_stop = None
 
     def _continuous_stop_and_wait(self):
         """Stop the silence monitor and wait for any in-progress transcription"""
@@ -1481,6 +1501,7 @@ class hyprwhsprApp:
     def _cleanup_recording_state(self):
         """Best-effort cleanup after any recording ends. Safe to call multiple times."""
         self._notify_capture_subscriber("", final=True)
+        self._autostop_stop_silence_monitor()
 
         try:
             self._clear_mic_osd_preview_text()

--- a/lib/main.py
+++ b/lib/main.py
@@ -678,9 +678,10 @@ class hyprwhsprApp:
                     should_start = False
 
             # Call _start_recording() outside the lock to avoid blocking release callback
+            # NOTE: auto-stop-on-silence is armed on RELEASE (tap-confirm path), not here, so a
+            # >=400ms hold stays pure push-to-talk and is never cut off mid-hold.
             if should_start:
                 self._start_recording(language_override=language_override)
-                self._autostop_start_silence_monitor()
         else:
             # Invalid mode, default to toggle behavior
             if self.is_recording:
@@ -727,7 +728,10 @@ class hyprwhsprApp:
                 # Tap (< 400ms): only stop if we didn't start recording on this press (toggle off)
                 if not started_this_press:
                     self._stop_recording()
-                # Otherwise, keep recording (tap started it, let it continue)
+                else:
+                    # Tap started the session and we're keeping it: arm auto-stop-on-silence now
+                    # (deferred from press so a >=400ms hold stays pure push-to-talk).
+                    self._autostop_start_silence_monitor()
 
     def _on_secondary_shortcut_triggered(self):
         """Handle secondary shortcut trigger (key press) with language override"""

--- a/lib/main.py
+++ b/lib/main.py
@@ -815,6 +815,10 @@ class hyprwhsprApp:
         self._autostop_silence_stop.clear()
         samples_needed = max(1, int(silence_timeout / self._POLL_INTERVAL))
         configured_threshold = self.config.get_setting('continuous_silence_threshold', 0)
+        try:
+            configured_threshold = float(configured_threshold)
+        except (TypeError, ValueError):
+            configured_threshold = 0  # unset/null in config -> auto-calibrate
 
         def monitor():
             try:

--- a/lib/src/audio_capture.py
+++ b/lib/src/audio_capture.py
@@ -1158,9 +1158,10 @@ class AudioCapture:
     def rolling_avg_level(self) -> float:
         """Rolling average RMS level over the last ~0.5s of audio chunks.
         More stable than current_level for silence detection."""
-        if not self._level_history:
-            return 0.0
-        return sum(self._level_history) / len(self._level_history)
+        with self.lock:
+            if not self._level_history:
+                return 0.0
+            return sum(self._level_history) / len(self._level_history)
     
     def _cleanup_stream(self):
         """Clean up the audio stream (idempotent - safe to call multiple times)"""

--- a/lib/src/config_manager.py
+++ b/lib/src/config_manager.py
@@ -52,6 +52,7 @@ class ConfigManager:
             'recording_mode': 'toggle',  # 'toggle' | 'push_to_talk' | 'auto' | 'continuous' (auto-paste on silence)
             'continuous_silence_seconds': 2.0,  # Seconds of silence before auto-pasting in continuous mode
             'continuous_silence_threshold': 0,  # RMS silence threshold; 0 = auto-calibrate from noise floor at session start
+            'silence_timeout': 0,   # Auto-stop after N seconds of silence in toggle/auto modes; 0 = disabled (arms only after speech)
             'grab_keys': False,     # Exclusive keyboard grab (false = safer, true = suppress shortcut from other apps)
             'use_hypr_bindings': False,  # Use Hyprland compositor bindings instead of evdev (disables GlobalShortcuts)
             'selected_device_path': None,  # Specific keyboard device path (e.g., '/dev/input/event3')

--- a/share/config.schema.json
+++ b/share/config.schema.json
@@ -482,6 +482,13 @@
       "maximum": 1,
       "default": 0,
       "description": "RMS level below which audio is considered silence in continuous mode. 0 (default) = auto-calibrate from noise floor at session start. Set manually if auto-calibration misbehaves on your mic."
+    },
+    "silence_timeout": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 30,
+      "default": 0,
+      "description": "Auto-stop recording after this many seconds of silence in toggle/auto modes. 0 (default) = disabled. The timer only arms after speech is detected, so it won't fire while you compose your first sentence."
     }
   }
 }


### PR DESCRIPTION
Implements the auto-stop-on-silence half of #201, following the shape we discussed.

## What
Adds an additive `silence_timeout` config (float seconds, **0 = off, default off**) that auto-stops recording after N seconds of silence in **toggle** and **auto** modes — press once, speak, and it finalizes itself when you go quiet.

## How
- New `_autostop_start/stop_silence_monitor` in `main.py`, modeled on `_continuous_start_silence_monitor` (auto-calibrated noise-floor threshold), but it calls `_stop_recording()` instead of `_continuous_flush_audio()` — ends the session rather than flush-and-continue. `_stop_recording()` already plays the stop beep, so that covers auto-stop feedback.
- **Arms only after speech is detected** (an `armed` flag set once `rolling_avg_level` crosses the threshold), so it can't fire while someone is composing their first sentence.
- Wired into both start paths: `_handle_shortcut_triggered` (toggle + auto) **and** the socket control handler (`record start` / `toggle`, i.e. external hotkeys). Torn down in `_stop_recording` (self-join-safe so the monitor can trigger the stop without deadlocking).
- `silence_timeout` added to the schema (0–30), default config, and `CONFIGURATION.md`.

## Behavior / safety
- **Default off → zero behavior change** for existing users.
- Manual stop and long-form are unchanged; purely additive.
- Applies only to toggle/auto (not push-to-talk / continuous / long-form).

## Testing
- Unit test against the real `_autostop_start_silence_monitor`: fires after speech→silence; does **not** fire on silence-before-speech (arm-after-speech guard); no-op when `silence_timeout=0`. All pass.
- Live end-to-end on the daemon (pywhispercpp + Vulkan, toggle mode): `record start` → `[AUTOSTOP] 2.5s of silence - stopping recording` → transcription pasted.

Refs #201. Happy to tune the threshold/arming, or add a test in whatever form fits CI (the app class is heavy to import, so I kept the harness verification out of tree for now).
