### PR TITLE
fix: flatten -r/--requirement includes when building temp requirement…

### DIFF
--- a/lib/src/backend_installer.py
+++ b/lib/src/backend_installer.py
@@ -122,6 +122,22 @@ def _plan_key(backend: str, provider: Optional[str], accelerated_variant: Option
     raise DependencyPlanError(f"No dependency manifest is defined for backend {backend!r}")
 
 
+def _requirements_option_argument(raw: str, short_option: str,
+                                  long_option: str) -> Optional[str]:
+    """Return a path argument for a pip requirements-file option, if present."""
+    line = raw.split('#', 1)[0].strip()
+    parts = line.split()
+    if parts and parts[0] in (short_option, long_option):
+        if len(parts) != 2:
+            raise DependencyPlanError(f"Invalid {long_option} directive: {raw.strip()}")
+        return parts[1]
+    if line.startswith(f'{long_option}='):
+        return line.split('=', 1)[1]
+    if line.startswith(short_option) and line != short_option:
+        return line[len(short_option):]
+    return None
+
+
 def _manifest_closure(manifest: Path) -> tuple[Path, ...]:
     """Resolve pip -r includes, rejecting missing/cyclic files before mutation."""
     ordered, visiting = [], set()
@@ -142,14 +158,9 @@ def _manifest_closure(manifest: Path) -> tuple[Path, ...]:
         except OSError as exc:
             raise DependencyPlanError(f"Cannot read dependency manifest {path}: {exc}") from exc
         for raw in lines:
-            line = raw.split('#', 1)[0].strip()
-            parts = line.split()
-            if parts and parts[0] in ('-r', '--requirement'):
-                if len(parts) != 2:
-                    raise DependencyPlanError(f"Invalid include in {path}: {raw.strip()}")
-                visit(path.parent / parts[1])
-            elif line.startswith('--requirement='):
-                visit(path.parent / line.split('=', 1)[1])
+            include = _requirements_option_argument(raw, '-r', '--requirement')
+            if include is not None:
+                visit(path.parent / include)
         visiting.remove(path)
         ordered.append(path)
 
@@ -1470,32 +1481,49 @@ def _extract_package_name(requirement_line: str) -> str:
 
 def _filter_requirements(requirements_file: Path, skip_packages: list) -> Path:
     """
-    Create a filtered requirements file, skipping specified packages.
-    Flattens -r/--requirement includes via _manifest_closure first, so
-    the result is self-contained and safe to write to /tmp.
+    Create a filtered, self-contained requirements file. Requirement includes
+    are expanded in place and relative constraint paths are made absolute, so
+    pip can safely consume the result from a temporary directory.
     Returns path to temp file (caller must clean up).
     """
     import tempfile
     skip_packages_lower = [pkg.lower() for pkg in skip_packages]
     temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False, encoding='utf-8')
     try:
-        for path in _manifest_closure(requirements_file):
-            with open(path, 'r', encoding='utf-8') as f_in:
-                for line in f_in:
-                    line_stripped = line.strip()
-                    # Skip empty lines/comments as-is
-                    if not line_stripped or line_stripped.startswith('#'):
-                        temp_file.write(line)
+        visiting = set()
+
+        def render(path: Path):
+            path = path.resolve()
+            if path in visiting:
+                raise DependencyPlanError(f"Cyclic dependency manifest include at {path}")
+            if not path.is_file():
+                raise DependencyPlanError(f"Dependency manifest is missing: {path}")
+            visiting.add(path)
+            try:
+                lines = path.read_text(encoding='utf-8').splitlines()
+                for line in lines:
+                    include = _requirements_option_argument(line, '-r', '--requirement')
+                    if include is not None:
+                        render(path.parent / include)
                         continue
-                    # Includes are already flattened above; drop the
-                    # directive itself so pip never re-resolves it.
-                    parts = line_stripped.split()
-                    if (parts and parts[0] in ('-r', '--requirement')) or line_stripped.startswith('--requirement='):
+
+                    constraint = _requirements_option_argument(line, '-c', '--constraint')
+                    if constraint is not None:
+                        constraint_path = (path.parent / constraint).resolve()
+                        if not constraint_path.is_file():
+                            raise DependencyPlanError(
+                                f"Dependency constraint is missing: {constraint_path}"
+                            )
+                        temp_file.write(f'--constraint {constraint_path}\n')
                         continue
-                    # Extract package name and check for exact match
-                    pkg_name = _extract_package_name(line_stripped)
+
+                    pkg_name = _extract_package_name(line)
                     if pkg_name not in skip_packages_lower:
-                        temp_file.write(line)
+                        temp_file.write(f'{line}\n')
+            finally:
+                visiting.remove(path)
+
+        render(requirements_file)
         temp_file.close()
         return Path(temp_file.name)
     except Exception:
@@ -2331,9 +2359,8 @@ print("Models cached successfully", flush=True)
                 skip_pygobject = _should_skip_pygobject()
                 skip_packages = ['pywhispercpp'] + (['PyGObject'] if skip_pygobject else [])
 
-                # _filter_requirements flattens -r/--requirement includes via
-                # _manifest_closure, so the temp file it returns is safe to
-                # pass to pip regardless of which directory it lives in.
+                # The filtered file expands requirements includes in place and
+                # anchors constraints, so it is safe to pass to pip from /tmp.
                 temp_req_path = None
                 try:
                     temp_req_path = _filter_requirements(requirements_file, skip_packages)
@@ -2348,7 +2375,7 @@ print("Models cached successfully", flush=True)
                         log_info("Cleaning up partial installation...")
                         # Uninstall any partially installed packages
                         try:
-                            run_command([str(pip_bin), 'uninstall', '-y'] + created_items['packages_installed'], 
+                            run_command([str(pip_bin), 'uninstall', '-y'] + created_items['packages_installed'],
                                       check=False, capture_output=True)
                         except Exception:
                             pass

--- a/lib/src/backend_installer.py
+++ b/lib/src/backend_installer.py
@@ -1471,23 +1471,31 @@ def _extract_package_name(requirement_line: str) -> str:
 def _filter_requirements(requirements_file: Path, skip_packages: list) -> Path:
     """
     Create a filtered requirements file, skipping specified packages.
+    Flattens -r/--requirement includes via _manifest_closure first, so
+    the result is self-contained and safe to write to /tmp.
     Returns path to temp file (caller must clean up).
     """
     import tempfile
     skip_packages_lower = [pkg.lower() for pkg in skip_packages]
     temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False, encoding='utf-8')
     try:
-        with open(requirements_file, 'r', encoding='utf-8') as f_in:
-            for line in f_in:
-                line_stripped = line.strip()
-                # Skip empty lines/comments as-is
-                if not line_stripped or line_stripped.startswith('#'):
-                    temp_file.write(line)
-                    continue
-                # Extract package name and check for exact match
-                pkg_name = _extract_package_name(line_stripped)
-                if pkg_name not in skip_packages_lower:
-                    temp_file.write(line)
+        for path in _manifest_closure(requirements_file):
+            with open(path, 'r', encoding='utf-8') as f_in:
+                for line in f_in:
+                    line_stripped = line.strip()
+                    # Skip empty lines/comments as-is
+                    if not line_stripped or line_stripped.startswith('#'):
+                        temp_file.write(line)
+                        continue
+                    # Includes are already flattened above; drop the
+                    # directive itself so pip never re-resolves it.
+                    parts = line_stripped.split()
+                    if (parts and parts[0] in ('-r', '--requirement')) or line_stripped.startswith('--requirement='):
+                        continue
+                    # Extract package name and check for exact match
+                    pkg_name = _extract_package_name(line_stripped)
+                    if pkg_name not in skip_packages_lower:
+                        temp_file.write(line)
         temp_file.close()
         return Path(temp_file.name)
     except Exception:
@@ -2321,48 +2329,36 @@ print("Models cached successfully", flush=True)
 
                 # Determine packages to skip
                 skip_pygobject = _should_skip_pygobject()
+                skip_packages = ['pywhispercpp'] + (['PyGObject'] if skip_pygobject else [])
 
-                # Use a writable temp directory instead of system directory
-                import tempfile
-                with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False, encoding='utf-8') as temp_req:
-                    temp_req_path = Path(temp_req.name)
-                    try:
-                        with open(requirements_file, 'r', encoding='utf-8') as f_in:
-                            for line in f_in:
-                                line_stripped = line.strip()
-                                # Extract package name for exact matching
-                                pkg_name = _extract_package_name(line_stripped)
-                                # Skip pywhispercpp (built separately with GPU support)
-                                if pkg_name == 'pywhispercpp':
-                                    continue
-                                # Skip PyGObject if already installed as system package
-                                if skip_pygobject and pkg_name == 'pygobject':
-                                    continue
-                                temp_req.write(line)
+                # _filter_requirements flattens -r/--requirement includes via
+                # _manifest_closure, so the temp file it returns is safe to
+                # pass to pip regardless of which directory it lives in.
+                temp_req_path = None
+                try:
+                    temp_req_path = _filter_requirements(requirements_file, skip_packages)
 
-                        temp_req.flush()
-
-                        if temp_req_path.stat().st_size > 0:
-                            run_command([str(pip_bin), 'install', '-r', str(temp_req_path)],
-                                       check=True, verbose=OutputController.get_verbosity().value >= VerbosityLevel.VERBOSE.value)
-                    except Exception as e:
-                        error_msg = f"Failed to install base Python dependencies: {e}"
-                        log_error(error_msg)
-                        if cleanup_on_failure:
-                            log_info("Cleaning up partial installation...")
-                            # Uninstall any partially installed packages
-                            try:
-                                run_command([str(pip_bin), 'uninstall', '-y'] + created_items['packages_installed'], 
-                                          check=False, capture_output=True)
-                            except Exception:
-                                pass
-                        set_install_state('failed', error_msg)
-                        _cleanup_partial_installation(created_items, pip_bin)
-                        return False
-                    finally:
-                        # Clean up temp file
-                        if temp_req_path.exists():
-                            temp_req_path.unlink()
+                    if temp_req_path.stat().st_size > 0:
+                        run_command([str(pip_bin), 'install', '-r', str(temp_req_path)],
+                                   check=True, verbose=OutputController.get_verbosity().value >= VerbosityLevel.VERBOSE.value)
+                except Exception as e:
+                    error_msg = f"Failed to install base Python dependencies: {e}"
+                    log_error(error_msg)
+                    if cleanup_on_failure:
+                        log_info("Cleaning up partial installation...")
+                        # Uninstall any partially installed packages
+                        try:
+                            run_command([str(pip_bin), 'uninstall', '-y'] + created_items['packages_installed'], 
+                                      check=False, capture_output=True)
+                        except Exception:
+                            pass
+                    set_install_state('failed', error_msg)
+                    _cleanup_partial_installation(created_items, pip_bin)
+                    return False
+                finally:
+                    # Clean up temp file
+                    if temp_req_path is not None and temp_req_path.exists():
+                        temp_req_path.unlink()
                 
                 # Remove any pre-existing pywhispercpp
                 run_command([str(pip_bin), 'uninstall', '-y', 'pywhispercpp'], check=False, capture_output=True)

--- a/tests/test_dependency_plans.py
+++ b/tests/test_dependency_plans.py
@@ -55,6 +55,40 @@ class DependencyPlanTests(unittest.TestCase):
                 second = backend_installer.resolve_dependency_plan('rest-api')
             self.assertNotEqual(first.fingerprint, second.fingerprint)
 
+    def test_filter_requirements_flattens_includes_for_temp_file_safety(self):
+        """
+        Regression test: _filter_requirements() used to copy `-r`/`--requirement`
+        lines from the source manifest verbatim into a NamedTemporaryFile under
+        /tmp. pip resolves such relative includes against the *including*
+        file's own directory, so a manifest like requirements-pywhispercpp.txt
+        (which starts with `-r requirements.txt`) produced a temp file whose
+        nested include silently pointed at the nonexistent
+        /tmp/requirements.txt, failing with "Could not open requirements
+        file: ... '/tmp/requirements.txt'" even though the flattened
+        dependency list was otherwise correct.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / 'requirements.txt').write_text(
+                'numpy\n# comment\nPyGObject>=3.50\n', encoding='utf-8'
+            )
+            (root / 'requirements-pywhispercpp.txt').write_text(
+                '-r requirements.txt\npywhispercpp==1.5.0\n', encoding='utf-8'
+            )
+            temp_path = backend_installer._filter_requirements(
+                root / 'requirements-pywhispercpp.txt', ['PyGObject']
+            )
+            try:
+                content = temp_path.read_text(encoding='utf-8')
+            finally:
+                temp_path.unlink()
+
+        self.assertNotIn('-r ', content)
+        self.assertNotIn('--requirement', content)
+        self.assertIn('numpy', content)
+        self.assertIn('pywhispercpp==1.5.0', content)
+        self.assertNotIn('PyGObject', content)
+
     def test_missing_include_is_actionable(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_dependency_plans.py
+++ b/tests/test_dependency_plans.py
@@ -89,6 +89,35 @@ class DependencyPlanTests(unittest.TestCase):
         self.assertIn('pywhispercpp==1.5.0', content)
         self.assertNotIn('PyGObject', content)
 
+    def test_filter_requirements_preserves_include_position_and_constraints(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            constraints = root / 'constraints.txt'
+            constraints.write_text('numpy<3\n', encoding='utf-8')
+            (root / 'common.txt').write_text('included-package', encoding='utf-8')
+            (root / 'requirements.txt').write_text(
+                'before-package\n-rcommon.txt\nafter-package\n-c constraints.txt\n',
+                encoding='utf-8',
+            )
+
+            temp_path = backend_installer._filter_requirements(
+                root / 'requirements.txt', []
+            )
+            try:
+                content = temp_path.read_text(encoding='utf-8')
+            finally:
+                temp_path.unlink()
+
+        self.assertEqual(
+            content.splitlines(),
+            [
+                'before-package',
+                'included-package',
+                'after-package',
+                f'--constraint {constraints.resolve()}',
+            ],
+        )
+
     def test_missing_include_is_actionable(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
Fixes #214

## Fix
- Flatten includes via the existing `_manifest_closure()` helper (already used for dependency-fingerprint hashing) before filtering, so the temp file is self-contained.
- Replace the inline duplicate in the GPU path with a call to the fixed `_filter_requirements()`.
- Add a regression test.

## Testing
- `python3 -m unittest discover -s tests -p "test_dependency_plans.py"`- 13/13 (was 12/12, +1 new)