### PR TITLE
feat: post transcription hook scripts can consume transcription text

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -988,7 +988,7 @@ GNOME/Mutter lacks layer-shell, so visual feedback uses notifications. Injection
 
 ### Post-transcription hook
 
-Pipe each transcription through a shell command before it's pasted. Stdin receives the (preprocessed) transcription; non-empty stdout replaces it. Empty stdout leaves the text unchanged, so the same mechanism works for both transforms and fire-and-forget observers.
+Pipe each transcription through a shell command before it's pasted. Stdin receives the (preprocessed) transcription; non-empty stdout replaces it. Empty stdout leaves the text unchanged, so the same mechanism works for both transforms and fire-and-forget observers. A hook that exits with status `77` consumes the transcription successfully and prevents it from being pasted.
 
 ```jsonc
 {
@@ -1017,7 +1017,7 @@ Two environment variables are exported to the hook:
 - `HYPRWHSPR_MODEL` — the active whisper model
 - `HYPRWHSPR_BACKEND` — the active transcription backend
 
-The hook runs under a 5-second timeout. On timeout, non-zero exit, or any subprocess error, the original text is preserved — a broken hook will never silently eat a dictation. Errors are logged to the service journal.
+The hook runs under a 5-second timeout. Exit status `77` is reserved for an intentional consume result; stdout is ignored and the transcription is not pasted. On timeout, any other non-zero exit, or any subprocess error, the original text is preserved — a broken hook will never silently eat a dictation. Errors are logged to the service journal.
 
 Note: the command runs under `shell=True`, so pipes, redirects, and command chaining work as expected. Treat `post_transcription_hook` as trusted config (same threat model as the rest of `config.json`).
 

--- a/lib/src/text_injector.py
+++ b/lib/src/text_injector.py
@@ -12,6 +12,8 @@ import time
 import threading
 import json
 import ast
+from dataclasses import dataclass
+from enum import Enum
 from typing import Optional, Dict, Any, List, Tuple
 
 try:
@@ -52,6 +54,22 @@ class _LazyPyperclip:
 
 
 pyperclip = _LazyPyperclip()
+
+
+POST_TRANSCRIPTION_HOOK_CONSUMED_EXIT_CODE = 77
+
+
+class _PostTranscriptionHookOutcome(Enum):
+    PRESERVE = "preserve"
+    REPLACE = "replace"
+    CONSUME = "consume"
+
+
+@dataclass(frozen=True)
+class _PostTranscriptionHookResult:
+    outcome: _PostTranscriptionHookOutcome
+    text: str
+
 
 DEFAULT_PASTE_KEYCODE = 47  # Linux evdev KEY_V on QWERTY
 NON_XKB_INPUT_METHOD_LAYOUT = '__non_xkb_input_method__'
@@ -1110,7 +1128,11 @@ except Exception:
 
         # Preprocess; also trim trailing newlines (avoid unwanted Enter)
         processed_text = self._preprocess_text(text).rstrip("\r\n")
-        processed_text = self._run_post_transcription_hook(processed_text) + ' '
+        hook_result = self._run_post_transcription_hook(processed_text)
+        if hook_result.outcome == _PostTranscriptionHookOutcome.CONSUME:
+            print("Post-transcription hook consumed transcription")
+            return True
+        processed_text = hook_result.text + ' '
 
         try:
             inject_mode = None
@@ -1199,18 +1221,20 @@ except Exception:
 
         return processed
 
-    def _run_post_transcription_hook(self, text: str) -> str:
-        """Pipe text through the user's post_transcription_hook shell command.
+    def _run_post_transcription_hook(self, text: str) -> _PostTranscriptionHookResult:
+        """Run the user's post_transcription_hook shell command.
 
-        Stdin = text; non-empty stdout replaces it (empty stdout = observer-only).
-        Env: HYPRWHSPR_MODEL, HYPRWHSPR_BACKEND. 5s timeout. Any error
-        preserves the original text — a broken hook must never eat a dictation.
+        Stdin = text; non-empty stdout replaces it (empty stdout preserves it).
+        Exit code 77 consumes the transcription without pasting it. Other errors
+        preserve the original text — a broken hook must never eat a dictation.
+        Env: HYPRWHSPR_MODEL, HYPRWHSPR_BACKEND. 5s timeout.
         """
+        preserve = _PostTranscriptionHookResult(_PostTranscriptionHookOutcome.PRESERVE, text)
         if not (self.config_manager and text):
-            return text
+            return preserve
         cmd = self.config_manager.get_setting('post_transcription_hook', None)
         if not (isinstance(cmd, str) and cmd.strip()):
-            return text
+            return preserve
 
         env = os.environ.copy()
         env['HYPRWHSPR_MODEL'] = str(self.config_manager.get_setting('model', '') or '')
@@ -1225,13 +1249,17 @@ except Exception:
             )
         except Exception as e:
             print(f"post_transcription_hook failed: {e}", flush=True)
-            return text
+            return preserve
+        if result.returncode == POST_TRANSCRIPTION_HOOK_CONSUMED_EXIT_CODE:
+            return _PostTranscriptionHookResult(_PostTranscriptionHookOutcome.CONSUME, "")
         if result.returncode != 0:
             stderr = (result.stderr or '').strip()
             print(f"post_transcription_hook exited {result.returncode}: {stderr}", flush=True)
-            return text
+            return preserve
         out = result.stdout.rstrip("\r\n")
-        return out if out else text
+        if not out:
+            return preserve
+        return _PostTranscriptionHookResult(_PostTranscriptionHookOutcome.REPLACE, out)
 
     def _apply_word_overrides(self, text: str) -> str:
         """Apply user-defined word overrides to the text"""

--- a/share/config.schema.json
+++ b/share/config.schema.json
@@ -165,7 +165,7 @@
     "post_transcription_hook": {
       "type": ["string", "null"],
       "default": null,
-      "description": "Shell command run after preprocessing, before paste. Stdin receives the transcription; non-empty stdout replaces it. Empty stdout = observer-only (original text is kept). Env vars HYPRWHSPR_MODEL and HYPRWHSPR_BACKEND are set. Subject to a 5s timeout; errors pass through the original text."
+      "description": "Shell command run after preprocessing, before paste. Stdin receives the transcription; non-empty stdout replaces it. Empty stdout preserves the original text. Exit status 77 intentionally consumes the transcription and skips paste. Env vars HYPRWHSPR_MODEL and HYPRWHSPR_BACKEND are set. Subject to a 5s timeout; other errors pass through the original text."
     },
     "clipboard_behavior": {
       "type": "boolean",

--- a/tests/test_text_injector_injection.py
+++ b/tests/test_text_injector_injection.py
@@ -12,7 +12,12 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "lib" / "src"))
 sys.modules.setdefault("pyperclip", types.SimpleNamespace(copy=lambda text: None, paste=lambda: ""))
 
-from text_injector import TextInjector, _LazyPyperclip
+from text_injector import (
+    POST_TRANSCRIPTION_HOOK_CONSUMED_EXIT_CODE,
+    TextInjector,
+    _LazyPyperclip,
+    _PostTranscriptionHookOutcome,
+)
 
 
 class ConfigStub:
@@ -21,6 +26,9 @@ class ConfigStub:
 
     def get_setting(self, name, default=None):
         return self.settings.get(name, default)
+
+    def get_word_overrides(self):
+        return self.settings.get("word_overrides", {})
 
 
 class TextInjectorInjectionTests(unittest.TestCase):
@@ -981,6 +989,71 @@ class TextInjectorInjectionTests(unittest.TestCase):
 
         self.assertEqual(chord, "ctrl+y")
         self.assertEqual(buf.getvalue(), "")
+
+
+    def test_post_hook_consume_exit_code_returns_consume_result(self):
+        injector = self._injector()
+        injector.config_manager = ConfigStub({"post_transcription_hook": "command"})
+        completed = types.SimpleNamespace(
+            returncode=POST_TRANSCRIPTION_HOOK_CONSUMED_EXIT_CODE,
+            stdout="ignored output",
+            stderr="",
+        )
+
+        with mock.patch("text_injector.subprocess.run", return_value=completed):
+            result = injector._run_post_transcription_hook("open terminal")
+
+        self.assertEqual(result.outcome, _PostTranscriptionHookOutcome.CONSUME)
+        self.assertEqual(result.text, "")
+
+    def test_post_hook_empty_output_preserves_original_text(self):
+        injector = self._injector()
+        injector.config_manager = ConfigStub({"post_transcription_hook": "command"})
+        completed = types.SimpleNamespace(returncode=0, stdout="\n", stderr="")
+
+        with mock.patch("text_injector.subprocess.run", return_value=completed):
+            result = injector._run_post_transcription_hook("hello")
+
+        self.assertEqual(result.outcome, _PostTranscriptionHookOutcome.PRESERVE)
+        self.assertEqual(result.text, "hello")
+
+    def test_post_hook_nonempty_output_replaces_text(self):
+        injector = self._injector()
+        injector.config_manager = ConfigStub({"post_transcription_hook": "command"})
+        completed = types.SimpleNamespace(returncode=0, stdout="replacement\n", stderr="")
+
+        with mock.patch("text_injector.subprocess.run", return_value=completed):
+            result = injector._run_post_transcription_hook("hello")
+
+        self.assertEqual(result.outcome, _PostTranscriptionHookOutcome.REPLACE)
+        self.assertEqual(result.text, "replacement")
+
+    def test_post_hook_failure_preserves_original_text(self):
+        injector = self._injector()
+        injector.config_manager = ConfigStub({"post_transcription_hook": "command"})
+        completed = types.SimpleNamespace(returncode=1, stdout="replacement", stderr="failed")
+
+        with mock.patch("text_injector.subprocess.run", return_value=completed):
+            result = injector._run_post_transcription_hook("hello")
+
+        self.assertEqual(result.outcome, _PostTranscriptionHookOutcome.PRESERVE)
+        self.assertEqual(result.text, "hello")
+
+    def test_consume_result_skips_injection(self):
+        injector = self._injector()
+        consumed = mock.Mock(
+            outcome=_PostTranscriptionHookOutcome.CONSUME,
+            text="",
+        )
+
+        with (
+            mock.patch.object(injector, "_preprocess_text", return_value="open terminal"),
+            mock.patch.object(injector, "_run_post_transcription_hook", return_value=consumed),
+            mock.patch.object(injector, "_inject_via_clipboard_and_hotkey") as inject,
+        ):
+            self.assertTrue(injector.inject_text("open terminal"))
+
+        inject.assert_not_called()
 
 
 class LazyPyperclipTests(unittest.TestCase):

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -276,8 +276,8 @@ import "../styles/global.css";
                             <h3>Post-transcription hook</h3>
                             <p>
                                 Pipe every transcription through your own shell
-                                command before it pastes — reformat, route, or
-                                log it.
+                                command before it pastes — reformat, route, log,
+                                or consume it without pasting.
                             </p>
                         </div>
 


### PR DESCRIPTION
Adds an explicit consume protocol for post_transcription_hook.

Hooks can now exit with status 77 to indicate that they handled the transcription and that hyprwhspr should not paste it.

### Changes

- Added explicit preserve, replace, and consume hook outcomes.
- Exit code 77 skips clipboard, paste, and auto-submit behavior.
- Preserved existing behavior for:
  - Exit 0 with stdout: replace transcription
  - Exit 0 with empty stdout: preserve transcription
  - Other failures: preserve original transcription