### PR TITLE
Add GPT Live Transcribe support

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -620,17 +620,29 @@ Two modes available (set `realtime_mode` in your config):
 - **transcribe** (default) - Pure speech-to-text, more expensive than HTTP
 - **converse** - Voice-to-AI: speak and get AI responses, configurable via `hyprwhspr config edit`
 
+Available transcription models:
+
+- **GPT Live Transcribe** (`gpt-live-transcribe`) - Recommended low-latency streaming transcription model
+- **GPT Realtime Whisper** (`gpt-realtime-whisper`) - Legacy streaming transcription model
+
+Both dedicated transcription models require `realtime_mode: "transcribe"`.
+
 ```jsonc
 {
     "transcription_backend": "realtime-ws",
     "websocket_provider": "openai",
-    "websocket_model": "gpt-realtime-whisper",
+    "websocket_model": "gpt-live-transcribe",
     "realtime_mode": "transcribe",       // "transcribe" or "converse"
     "realtime_transcription_delay": "low", // "minimal", "low", "medium", "high", or "xhigh"
     "realtime_timeout": 30,              // Advanced: seconds to wait after stop for final transcript
     "realtime_buffer_max_seconds": 5     // Advanced: max unsent audio backlog (seconds) before dropping old chunks
 }
 ```
+
+For GPT Live Transcribe, hyprwhspr sends the configured scalar `language` as
+OpenAI's single-entry `languages` hint, streams 24 kHz PCM audio, and explicitly
+commits the turn when recording stops. The delay setting trades partial-result
+latency for transcription accuracy.
 
 #### Google Gemini
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -622,7 +622,7 @@ Two modes available (set `realtime_mode` in your config):
 
 Available transcription models:
 
-- **GPT Live Transcribe** (`gpt-live-transcribe`) - Recommended low-latency streaming transcription model
+- **GPT Live Transcribe** (`gpt-live-transcribe`) - Live streaming with the best OSD previews; higher cost
 - **GPT Realtime Whisper** (`gpt-realtime-whisper`) - Legacy streaming transcription model
 
 Both dedicated transcription models require `realtime_mode: "transcribe"`.
@@ -643,6 +643,8 @@ For GPT Live Transcribe, hyprwhspr sends the configured scalar `language` as
 OpenAI's single-entry `languages` hint, streams 24 kHz PCM audio, and explicitly
 commits the turn when recording stops. The delay setting trades partial-result
 latency for transcription accuracy.
+
+Its `prompt` uses the existing active-language fallback: `whisper_prompt_<language>` → `whisper_prompt` → omitted.
 
 #### Google Gemini
 

--- a/lib/src/backends/realtime_ws_backend.py
+++ b/lib/src/backends/realtime_ws_backend.py
@@ -55,6 +55,31 @@ class RealtimeWsBackend(TranscriptionBackend):
         # Owned by the manager so it survives backend re-creation on resume
         return self._manager._realtime_partial_callback
 
+    def _resolve_whisper_prompt(self, language: Optional[str]) -> Optional[str]:
+        """Resolve the existing language-specific Whisper prompt fallback."""
+        language_prompt = None
+        if language:
+            language_prompt = self.config.get_setting(f'whisper_prompt_{language}', None)
+        return language_prompt or self.config.get_setting('whisper_prompt', None) or None
+
+    def _update_client_language(
+        self,
+        language: Optional[str],
+        model_id: Optional[str] = None,
+    ) -> None:
+        """Keep GPT Live Transcribe's language hint and prompt in sync."""
+        if not self._realtime_client:
+            return
+
+        active_model = model_id or getattr(self._realtime_client, 'model', None)
+        if active_model == 'gpt-live-transcribe':
+            self._realtime_client.update_transcription_config(
+                language,
+                self._resolve_whisper_prompt(language),
+            )
+        else:
+            self._realtime_client.update_language(language)
+
     def initialize(self) -> bool:
         """Configure the Realtime WebSocket backend and connect the client"""
         # Validate WebSocket configuration
@@ -240,8 +265,8 @@ class RealtimeWsBackend(TranscriptionBackend):
 
             instructions = ' '.join(instructions_parts) if instructions_parts else None
 
-            # Set language in realtime client (for session.update)
-            self._realtime_client.language = language
+            # Set language and any model-specific transcription context.
+            self._update_client_language(language, model_id=model_id)
 
             delay = self.config.get_setting('realtime_transcription_delay', 'low')
             self._realtime_client.set_transcription_delay(delay)
@@ -360,7 +385,7 @@ class RealtimeWsBackend(TranscriptionBackend):
             # doing so would trigger a reconnect and silently drop the audio.
             if language_override is not None:
                 if getattr(self._realtime_client, 'supports_mid_session_language_update', True):
-                    self._realtime_client.update_language(language_override)
+                    self.update_language(language_override)
                 else:
                     print(
                         f'[REALTIME] Provider does not support mid-session language override '
@@ -531,8 +556,7 @@ class RealtimeWsBackend(TranscriptionBackend):
 
     def update_language(self, language: Optional[str]) -> None:
         """Apply a language override to a connected client (no-op otherwise)."""
-        if self._realtime_client:
-            self._realtime_client.update_language(language)
+        self._update_client_language(language)
 
     def reinitialize(self) -> bool:
         """Re-establish the connection after suspend/resume (full re-init)."""

--- a/lib/src/backends/realtime_ws_backend.py
+++ b/lib/src/backends/realtime_ws_backend.py
@@ -28,6 +28,12 @@ except ImportError:
 from .base import TranscriptionBackend
 
 
+OPENAI_STREAMING_TRANSCRIPTION_MODELS = frozenset({
+    'gpt-live-transcribe',
+    'gpt-realtime-whisper',
+})
+
+
 class RealtimeWsBackend(TranscriptionBackend):
     """Streaming WebSocket backend; reconnects by full re-initialization on resume."""
 
@@ -195,8 +201,15 @@ class RealtimeWsBackend(TranscriptionBackend):
 
             # Initialize RealtimeClient with mode
             realtime_mode = self.config.get_setting('realtime_mode', 'transcribe')
-            if provider_id == 'openai' and model_id == 'gpt-realtime-whisper' and realtime_mode != 'transcribe':
-                print('ERROR: gpt-realtime-whisper is supported only with realtime_mode="transcribe"', flush=True)
+            if (
+                provider_id == 'openai'
+                and model_id in OPENAI_STREAMING_TRANSCRIPTION_MODELS
+                and realtime_mode != 'transcribe'
+            ):
+                print(
+                    f'ERROR: {model_id} is supported only with realtime_mode="transcribe"',
+                    flush=True,
+                )
                 return False
             self._realtime_client = RealtimeClient(mode=realtime_mode)
 
@@ -432,9 +445,9 @@ class RealtimeWsBackend(TranscriptionBackend):
                 and self.config.get_setting('mic_osd_pill_transcript_enabled', False)
             )
 
-        # Waveform: only gpt-realtime-whisper supports this today.
+        # Waveform: OpenAI's streaming transcription models emit live deltas.
         if provider_id == 'openai':
-            return model_id == 'gpt-realtime-whisper'
+            return model_id in OPENAI_STREAMING_TRANSCRIPTION_MODELS
 
         return False
 

--- a/lib/src/config_manager.py
+++ b/lib/src/config_manager.py
@@ -126,12 +126,12 @@ class ConfigManager:
             'rest_audio_format': 'wav',        # Audio format for remote transcription
             # WebSocket realtime backend settings
             'websocket_provider': None,        # Provider identifier for credential lookup (e.g., 'openai', 'google', 'elevenlabs')
-            'websocket_model': None,           # Model identifier (e.g., 'gpt-realtime-whisper')
+            'websocket_model': None,           # Model identifier (e.g., 'gpt-live-transcribe')
             'websocket_url': None,             # Optional: explicit WebSocket URL (auto-derived if None)
             'realtime_timeout': 30,            # Completion timeout (seconds)
             'realtime_buffer_max_seconds': 5,  # Max buffer before dropping chunks
             'realtime_mode': 'transcribe',      # 'transcribe' (speech-to-text) or 'converse' (voice-to-AI)
-            'realtime_transcription_delay': 'low',  # gpt-realtime-whisper delay: minimal|low|medium|high|xhigh
+            'realtime_transcription_delay': 'low',  # OpenAI streaming delay: minimal|low|medium|high|xhigh
             # whisper.cpp (pywhispercpp) backend settings
             'pywhispercpp_use_vad': False,               # Native Silero VAD (strips silence, reduces hallucinations); auto-downloads ~1MB ggml-silero model when enabled
             # ONNX-ASR backend settings (CPU-optimized)

--- a/lib/src/provider_registry.py
+++ b/lib/src/provider_registry.py
@@ -17,6 +17,13 @@ PROVIDERS: Dict[str, Dict] = {
         'api_key_prefix': 'sk-',
         'api_key_description': 'OpenAI API key (starts with sk-)',
         'models': {
+            'gpt-live-transcribe': {
+                'name': 'GPT Live Transcribe',
+                'description': 'Recommended low-latency streaming transcription model',
+                'body': {'model': 'gpt-live-transcribe'},
+                'realtime_model': True,
+                'hidden': True
+            },
             'gpt-4o-transcribe': {
                 'name': 'GPT-4o Transcribe',
                 'description': 'Latest model with best accuracy',
@@ -34,7 +41,7 @@ PROVIDERS: Dict[str, Dict] = {
             },
             'gpt-realtime-whisper': {
                 'name': 'GPT Realtime Whisper',
-                'description': 'Recommended realtime streaming transcription model',
+                'description': 'Legacy realtime streaming transcription model',
                 'body': {'model': 'gpt-realtime-whisper'},
                 'realtime_model': True,
                 'hidden': True

--- a/lib/src/provider_registry.py
+++ b/lib/src/provider_registry.py
@@ -19,7 +19,7 @@ PROVIDERS: Dict[str, Dict] = {
         'models': {
             'gpt-live-transcribe': {
                 'name': 'GPT Live Transcribe',
-                'description': 'Recommended low-latency streaming transcription model',
+                'description': 'Live streaming with the best OSD previews; higher cost',
                 'body': {'model': 'gpt-live-transcribe'},
                 'realtime_model': True,
                 'hidden': True

--- a/lib/src/realtime_client.py
+++ b/lib/src/realtime_client.py
@@ -192,11 +192,21 @@ class RealtimeClient(WebSocketRealtimeClientBase):
             # Build transcription config - omit language for auto-detect
             model = self.model or 'gpt-4o-mini-transcribe'
             transcription_config = {'model': model}
+
+            is_live_transcribe = model == 'gpt-live-transcribe'
             if self.language:
-                transcription_config['language'] = self.language
+                if is_live_transcribe:
+                    transcription_config['languages'] = [self.language]
+                else:
+                    transcription_config['language'] = self.language
+
+            # Do not map the existing Whisper task instructions to the new
+            # model's recording-context prompt; that needs a separate config
+            # decision alongside keyword support.
 
             is_realtime_whisper = model == 'gpt-realtime-whisper'
-            if is_realtime_whisper:
+            is_streaming_transcription = is_realtime_whisper or is_live_transcribe
+            if is_streaming_transcription:
                 transcription_config['delay'] = self._validated_transcription_delay()
 
             session_data = {
@@ -208,7 +218,7 @@ class RealtimeClient(WebSocketRealtimeClientBase):
                             'rate': 24000
                         },
                         'transcription': transcription_config,
-                        'turn_detection': None if is_realtime_whisper else {
+                        'turn_detection': None if is_streaming_transcription else {
                             'type': 'server_vad',
                             'threshold': 0.5,
                             'prefix_padding_ms': 300,
@@ -256,7 +266,7 @@ class RealtimeClient(WebSocketRealtimeClientBase):
             self._send_session_update()
 
     def set_transcription_delay(self, delay: str):
-        """Set gpt-realtime-whisper transcription delay."""
+        """Set the OpenAI streaming transcription delay."""
         self.transcription_delay = self._normalize_transcription_delay(delay)
         if self.connected:
             self._send_session_update()

--- a/lib/src/realtime_client.py
+++ b/lib/src/realtime_client.py
@@ -28,6 +28,7 @@ class RealtimeClient(WebSocketRealtimeClientBase):
         """
         super().__init__(mode=mode)
         self.transcription_delay = 'low'
+        self.transcription_prompt = None
         self.partial_transcript_callback = None
         self.sample_rate = 24000  # OpenAI Realtime API requires 24kHz
 
@@ -200,9 +201,8 @@ class RealtimeClient(WebSocketRealtimeClientBase):
                 else:
                     transcription_config['language'] = self.language
 
-            # Do not map the existing Whisper task instructions to the new
-            # model's recording-context prompt; that needs a separate config
-            # decision alongside keyword support.
+            if is_live_transcribe and self.transcription_prompt:
+                transcription_config['prompt'] = self.transcription_prompt
 
             is_realtime_whisper = model == 'gpt-realtime-whisper'
             is_streaming_transcription = is_realtime_whisper or is_live_transcribe
@@ -255,15 +255,24 @@ class RealtimeClient(WebSocketRealtimeClientBase):
         except Exception as e:
             self._log(f'Failed to send session.update: {e}')
 
+    def update_transcription_config(
+        self,
+        language: Optional[str],
+        prompt: Optional[str],
+    ):
+        """Update GPT Live Transcribe language and prompt together."""
+        self.language = language
+        self.transcription_prompt = prompt
+        if self.connected:
+            self._send_session_update()
+
     def update_language(self, language: Optional[str]):
         """Update the language for transcription and resend session.update
 
         Args:
             language: Language code (e.g., 'en', 'it', 'fr') or None for auto-detect
         """
-        self.language = language
-        if self.connected:
-            self._send_session_update()
+        self.update_transcription_config(language, self.transcription_prompt)
 
     def set_transcription_delay(self, delay: str):
         """Set the OpenAI streaming transcription delay."""

--- a/share/config.schema.json
+++ b/share/config.schema.json
@@ -286,7 +286,7 @@
     "websocket_model": {
       "type": ["string", "null"],
       "default": null,
-      "description": "Model identifier for WebSocket backend (e.g., 'gpt-realtime-whisper', 'gemini-3.1-flash-live-preview')"
+      "description": "Model identifier for WebSocket backend (e.g., 'gpt-live-transcribe', 'gemini-3.1-flash-live-preview')"
     },
     "websocket_url": {
       "type": ["string", "null"],
@@ -315,7 +315,7 @@
       "type": "string",
       "enum": ["minimal", "low", "medium", "high", "xhigh"],
       "default": "low",
-      "description": "Latency/accuracy delay setting for OpenAI gpt-realtime-whisper transcription"
+      "description": "Latency/accuracy delay setting for OpenAI streaming transcription models"
     },
     "pywhispercpp_use_vad": {
       "type": "boolean",

--- a/tests/test_elevenlabs_pill_preview.py
+++ b/tests/test_elevenlabs_pill_preview.py
@@ -224,5 +224,53 @@ class OpenAIRealtimeModeTests(unittest.TestCase):
         self.assertIsNone(backend._realtime_client)
 
 
+class OpenAIRealtimePromptTests(unittest.TestCase):
+    def test_active_language_selects_existing_whisper_prompt_fallback(self):
+        cases = (
+            (
+                "language-specific prompt",
+                {
+                    "whisper_prompt": "Global prompt",
+                    "whisper_prompt_de": "German prompt",
+                },
+                "German prompt",
+            ),
+            (
+                "global fallback",
+                {"whisper_prompt": "Global prompt"},
+                "Global prompt",
+            ),
+            (
+                "empty language-specific fallback",
+                {
+                    "whisper_prompt": "Global prompt",
+                    "whisper_prompt_de": "",
+                },
+                "Global prompt",
+            ),
+            ("omitted", {"whisper_prompt": ""}, None),
+        )
+
+        for name, prompt_config, expected_prompt in cases:
+            with self.subTest(name=name):
+                config = FakeConfig({
+                    "websocket_provider": "openai",
+                    "websocket_model": "gpt-live-transcribe",
+                    **prompt_config,
+                })
+                backend = RealtimeWsBackend(FakeManager(config))
+                client = mock.Mock()
+                client.model = "gpt-live-transcribe"
+                backend._realtime_client = client
+
+                backend.update_language("de")
+
+                client.update_transcription_config.assert_called_once_with(
+                    "de",
+                    expected_prompt,
+                )
+                client.update_language.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_elevenlabs_pill_preview.py
+++ b/tests/test_elevenlabs_pill_preview.py
@@ -1,6 +1,7 @@
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -155,6 +156,17 @@ class ElevenLabsRealtimePreviewTests(unittest.TestCase):
 
         self.assertIsNotNone(self.client.callback)
 
+    def test_gpt_live_transcribe_preview_is_enabled_for_waveform(self):
+        self.manager.config.values.update({
+            "websocket_provider": "openai",
+            "websocket_model": "gpt-live-transcribe",
+            "mic_osd_style": "waveform",
+        })
+
+        self._apply()
+
+        self.assertIsNotNone(self.client.callback)
+
     def test_openai_preview_is_also_shown_in_pill(self):
         self.manager.config.values.update({
             "websocket_provider": "openai",
@@ -192,6 +204,24 @@ class ElevenLabsRealtimePreviewTests(unittest.TestCase):
         previews = self._apply()
 
         self.assertEqual(previews, [""])
+
+
+class OpenAIRealtimeModeTests(unittest.TestCase):
+    def test_gpt_live_transcribe_rejects_converse_mode(self):
+        config = FakeConfig({
+            "websocket_provider": "openai",
+            "websocket_model": "gpt-live-transcribe",
+            "realtime_mode": "converse",
+        })
+        backend = RealtimeWsBackend(FakeManager(config))
+
+        with mock.patch(
+            "backends.realtime_ws_backend.get_credential",
+            return_value="sk-test-openai-key",
+        ):
+            self.assertFalse(backend.initialize())
+
+        self.assertIsNone(backend._realtime_client)
 
 
 if __name__ == "__main__":

--- a/tests/test_realtime_client.py
+++ b/tests/test_realtime_client.py
@@ -56,6 +56,63 @@ class RealtimeClientTests(unittest.TestCase):
             },
         )
 
+    def test_gpt_live_transcribe_session_payload(self):
+        client = self._client_with_ws("gpt-live-transcribe")
+        client.language = "en"
+        client.set_transcription_delay("high")
+        client.ws.sent.clear()
+
+        client._send_session_update()
+
+        self.assertEqual(
+            client.ws.sent[-1],
+            {
+                "type": "session.update",
+                "session": {
+                    "type": "transcription",
+                    "audio": {
+                        "input": {
+                            "format": {"type": "audio/pcm", "rate": 24000},
+                            "transcription": {
+                                "model": "gpt-live-transcribe",
+                                "languages": ["en"],
+                                "delay": "high",
+                            },
+                            "turn_detection": None,
+                        }
+                    },
+                },
+            },
+        )
+
+    def test_gpt_live_transcribe_uses_languages_array(self):
+        client = self._client_with_ws("gpt-live-transcribe")
+        client.language = "fr"
+
+        client._send_session_update()
+
+        transcription = client.ws.sent[-1]["session"]["audio"]["input"]["transcription"]
+        self.assertEqual(transcription["languages"], ["fr"])
+        self.assertNotIn("language", transcription)
+
+    def test_gpt_live_transcribe_propagates_delay(self):
+        client = self._client_with_ws("gpt-live-transcribe")
+        client.set_transcription_delay("xhigh")
+        client.ws.sent.clear()
+
+        client._send_session_update()
+
+        transcription = client.ws.sent[-1]["session"]["audio"]["input"]["transcription"]
+        self.assertEqual(transcription["delay"], "xhigh")
+
+    def test_gpt_live_transcribe_uses_manual_turn_detection(self):
+        client = self._client_with_ws("gpt-live-transcribe")
+
+        client._send_session_update()
+
+        audio_input = client.ws.sent[-1]["session"]["audio"]["input"]
+        self.assertIsNone(audio_input["turn_detection"])
+
     def test_non_whisper_transcription_session_keeps_vad_and_configured_model(self):
         client = self._client_with_ws("gpt-4o-mini-transcribe")
         client.language = "fr"

--- a/tests/test_realtime_client.py
+++ b/tests/test_realtime_client.py
@@ -58,7 +58,10 @@ class RealtimeClientTests(unittest.TestCase):
 
     def test_gpt_live_transcribe_session_payload(self):
         client = self._client_with_ws("gpt-live-transcribe")
-        client.language = "en"
+        client.update_transcription_config(
+            "en",
+            "Linux and software-development dictation.",
+        )
         client.set_transcription_delay("high")
         client.ws.sent.clear()
 
@@ -77,6 +80,7 @@ class RealtimeClientTests(unittest.TestCase):
                                 "model": "gpt-live-transcribe",
                                 "languages": ["en"],
                                 "delay": "high",
+                                "prompt": "Linux and software-development dictation.",
                             },
                             "turn_detection": None,
                         }
@@ -84,6 +88,14 @@ class RealtimeClientTests(unittest.TestCase):
                 },
             },
         )
+
+    def test_gpt_live_transcribe_omits_unset_prompt(self):
+        client = self._client_with_ws("gpt-live-transcribe")
+
+        client._send_session_update()
+
+        transcription = client.ws.sent[-1]["session"]["audio"]["input"]["transcription"]
+        self.assertNotIn("prompt", transcription)
 
     def test_gpt_live_transcribe_uses_languages_array(self):
         client = self._client_with_ws("gpt-live-transcribe")

--- a/tests/test_setup_command_scope.py
+++ b/tests/test_setup_command_scope.py
@@ -1,5 +1,6 @@
 import importlib
 import contextlib
+import io
 import sys
 import tempfile
 import types
@@ -65,6 +66,33 @@ class SetupCommandScopeTests(unittest.TestCase):
             clear=True,
         ):
             self.assertTrue(setup._is_gnome_or_mutter_session())
+
+    def test_gpt_live_transcribe_is_visible_in_realtime_setup_catalog(self):
+        class SelectFirstPrompt:
+            @staticmethod
+            def ask(*_args, **_kwargs):
+                return "1"
+
+        class AcceptDefaultConfirm:
+            @staticmethod
+            def ask(*_args, **_kwargs):
+                return True
+
+        output = io.StringIO()
+        with (
+            mock.patch.object(setup, "Prompt", SelectFirstPrompt),
+            mock.patch.object(setup, "Confirm", AcceptDefaultConfirm),
+            mock.patch.object(setup, "get_credential", return_value="sk-existing-key"),
+            mock.patch.object(setup, "save_credential", return_value=True),
+            contextlib.redirect_stdout(output),
+        ):
+            selection = setup._prompt_realtime_provider_model_selection()
+
+        self.assertEqual(
+            selection,
+            ("openai", "gpt-live-transcribe", "sk-existing-key", None),
+        )
+        self.assertIn("OpenAI: GPT Live Transcribe", output.getvalue())
 
 
 class ConfigDefaultTests(unittest.TestCase):


### PR DESCRIPTION
# Add GPT Live Transcribe support

## Summary

- add GPT Live Transcribe to the OpenAI realtime setup catalog
- generate its transcription session payload with `languages`, configured delay, prompt fallback, and manual turn detection
- keep it on the existing OpenAI WebSocket transport and transcript event handling
- restrict it to transcription mode and enable live OSD partial previews
- preserve GPT Realtime Whisper as a legacy option

## Model-specific behavior

GPT Live Transcribe uses the existing scalar `language` setting as a single-entry `languages` hint and does not send the legacy singular `language` field.

Its prompt uses the existing configuration fallback requested in review:

```text
whisper_prompt_<active language> → whisper_prompt → omitted
```

The active language and resolved prompt are updated together so language overrides cannot send mismatched context. The configured `realtime_transcription_delay` is forwarded, and recording stop explicitly commits the turn.

## Scope and follow-ups

GPT Live Transcribe is positioned as the higher-cost option with the best live OSD preview experience. Adding non-live `gpt-transcribe` as the default path is intentionally left for a follow-up.

Profiles, keywords, and a dedicated `openai_live_transcribe_prompt` setting are also deferred so this PR can land without introducing new configuration semantics. The existing scalar language setting remains unchanged.

References:

- [Realtime transcription guide](https://developers.openai.com/api/docs/guides/realtime-transcription)
- [Whisper migration guide](https://developers.openai.com/cookbook/examples/migrating_from_whisper_to_gpt_transcribe)

## Validation

- [x] exact GPT Live Transcribe session payload, including prompt
- [x] language-specific prompt, global fallback, and prompt omission
- [x] singular-to-array language conversion
- [x] delay propagation
- [x] manual turn detection
- [x] waveform partial-preview enablement
- [x] transcription-only mode guard
- [x] realtime setup/catalog visibility
- [x] tested successfully end to end

Focused validation:

```text
python -m unittest -v tests.test_realtime_client tests.test_elevenlabs_pill_preview
```

Result: 33 tests passed.

Full validation:

```text
python -m unittest discover -s tests -v
```

Result: 384 of 386 tests passed. The two untouched suspend-monitor tests error in this environment because the optional D-Bus/GLib bindings are unavailable, so `suspend_monitor.DBusGMainLoop` is not defined for their patch target.
