### PR TITLE
Add GPT Transcribe support

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -611,23 +611,31 @@ Connect to any backend, local or cloud, via your own custom configuration:
 
 ### Realtime WebSocket
 
-Persistent WebSocket transcription for committed turns and continuous streaming.
+Persistent WebSocket streaming. `realtime_mode` selects `transcribe` (speech-to-text, the default) or `converse`
+(voice-to-AI), but converse support varies by provider:
+
+| Provider | `transcribe` | `converse` |
+| --- | --- | --- |
+| OpenAI | Yes | Yes, on a `gpt-realtime-*` model |
+| Google Gemini | Yes | Yes |
+| ElevenLabs | Yes | No — hyprwhspr ignores `realtime_mode` |
+| Custom | Yes | Yes |
+
+Custom endpoints speak the OpenAI Realtime protocol. Set `websocket_provider: "custom"` and `websocket_url`.
 
 #### OpenAI Realtime
 
-Two modes are available (set `realtime_mode` in your config):
+Dedicated transcription models, all requiring `realtime_mode: "transcribe"`:
 
-- **transcribe** (default) - Pure speech-to-text; the selected model controls when transcription begins
-- **converse** - Voice-to-AI: speak and get AI responses, configurable via `hyprwhspr config edit`
+| Model | Transcript arrives | Notes |
+| --- | --- | --- |
+| `gpt-transcribe` | After you stop recording | Recommended: accurate, fast, inexpensive |
+| `gpt-live-transcribe` | Live, while you speak | Best OSD previews; higher cost |
+| `gpt-realtime-whisper` | Live, while you speak | Legacy |
 
-Available transcription models:
-
-- **GPT Transcribe** (`gpt-transcribe`) - Recommended for most users; accurate, fast, inexpensive, and starts after
-  commit
-- **GPT Live Transcribe** (`gpt-live-transcribe`) - Continuous live deltas and the best OSD previews; higher cost
-- **GPT Realtime Whisper** (`gpt-realtime-whisper`) - Legacy compatibility
-
-All three dedicated transcription models require `realtime_mode: "transcribe"`.
+None of the three support `converse` — that needs a `gpt-realtime-*` model, which `hyprwhspr setup` also offers.
+All three disable server-side VAD and commit the turn when recording stops. `realtime_transcription_delay`
+(partial-result latency vs. accuracy) and the continuous waveform OSD preview apply only to the two live models.
 
 ```jsonc
 {
@@ -640,31 +648,29 @@ All three dedicated transcription models require `realtime_mode: "transcribe"`.
 }
 ```
 
-For `converse` mode, `realtime_conversation_history` defaults to `"session"` so
-the assistant retains prior turns. Set it to `"turn"` to delete each completed
-turn from the provider while reusing the WebSocket; this prevents prior audio
-from being included as conversation context and billed again.
+In `converse` mode, `realtime_conversation_history` controls what the provider retains between turns:
 
-For a stateless voice-to-AI workflow, configure converse mode explicitly:
+- `"turn"` (default) - deletes each completed turn while reusing the WebSocket, so every turn starts with empty
+  context.
+- `"session"` - keeps prior turns for conversational context. The provider re-sends and bills that audio every
+  turn, so cost climbs as the session grows. Choose this only if you want a multi-turn assistant.
+
+For a stateless voice-to-AI workflow:
 
 ```jsonc
 {
     "transcription_backend": "realtime-ws",
     "websocket_provider": "openai",
-    "websocket_model": "gpt-realtime",
+    "websocket_model": "gpt-realtime-2.1",
     "realtime_mode": "converse",
     "realtime_conversation_history": "turn"
 }
 ```
 
-For GPT Transcribe, hyprwhspr sends the configured scalar `language` as OpenAI's single-entry `languages` hint, streams
-24 kHz PCM audio, and explicitly commits the turn when recording stops. Transcription begins after that commit; any
-deltas arrive while OpenAI processes the committed turn, not while you are still speaking.
-
-GPT Transcribe and GPT Live Transcribe both use the existing active-language prompt fallback:
-`whisper_prompt_<language>` → `whisper_prompt` → omitted. GPT Live Transcribe emits continuous live deltas and supports
-`realtime_transcription_delay`, which trades partial-result latency for final transcription accuracy. GPT Realtime
-Whisper remains available for legacy configurations.
+All OpenAI Realtime models stream 24 kHz PCM audio. For GPT Transcribe and GPT Live Transcribe, hyprwhspr sends the
+scalar `language` setting as OpenAI's single-entry `languages` hint and resolves the prompt through
+`whisper_prompt_<language>` → `whisper_prompt` → omitted. For GPT Realtime Whisper it sends a plain scalar
+`language` and no prompt.
 
 #### Google Gemini
 
@@ -681,7 +687,7 @@ Uses native 16kHz audio (no resampling) and server-side VAD.
 {
     "transcription_backend": "realtime-ws",
     "websocket_provider": "google",
-    "websocket_model": "gemini-3.1-flash-live-preview",
+    "websocket_model": "gemini-3.1-flash-live-preview",  // or gemini-2.5-flash-native-audio-preview-12-2025
     "realtime_mode": "transcribe",           // "transcribe" or "converse"
     "realtime_timeout": 30,                  // Advanced: seconds to wait after stop for final transcript
     "realtime_buffer_max_seconds": 5         // Advanced: max unsent audio backlog (seconds) before dropping old chunks

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -611,29 +611,30 @@ Connect to any backend, local or cloud, via your own custom configuration:
 
 ### Realtime WebSocket
 
-Low-latency streaming transcription.
+Persistent WebSocket transcription for committed turns and continuous streaming.
 
 #### OpenAI Realtime
 
-Two modes available (set `realtime_mode` in your config):
+Two modes are available (set `realtime_mode` in your config):
 
-- **transcribe** (default) - Pure speech-to-text, more expensive than HTTP
+- **transcribe** (default) - Pure speech-to-text; the selected model controls when transcription begins
 - **converse** - Voice-to-AI: speak and get AI responses, configurable via `hyprwhspr config edit`
 
 Available transcription models:
 
-- **GPT Live Transcribe** (`gpt-live-transcribe`) - Live streaming with the best OSD previews; higher cost
-- **GPT Realtime Whisper** (`gpt-realtime-whisper`) - Legacy streaming transcription model
+- **GPT Transcribe** (`gpt-transcribe`) - Recommended for most users; accurate, fast, inexpensive, and starts after
+  commit
+- **GPT Live Transcribe** (`gpt-live-transcribe`) - Continuous live deltas and the best OSD previews; higher cost
+- **GPT Realtime Whisper** (`gpt-realtime-whisper`) - Legacy compatibility
 
-Both dedicated transcription models require `realtime_mode: "transcribe"`.
+All three dedicated transcription models require `realtime_mode: "transcribe"`.
 
 ```jsonc
 {
     "transcription_backend": "realtime-ws",
     "websocket_provider": "openai",
-    "websocket_model": "gpt-live-transcribe",
+    "websocket_model": "gpt-transcribe",
     "realtime_mode": "transcribe",       // "transcribe" or "converse"
-    "realtime_transcription_delay": "low", // "minimal", "low", "medium", "high", or "xhigh"
     "realtime_timeout": 30,              // Advanced: seconds to wait after stop for final transcript
     "realtime_buffer_max_seconds": 5     // Advanced: max unsent audio backlog (seconds) before dropping old chunks
 }
@@ -656,12 +657,14 @@ For a stateless voice-to-AI workflow, configure converse mode explicitly:
 }
 ```
 
-For GPT Live Transcribe, hyprwhspr sends the configured scalar `language` as
-OpenAI's single-entry `languages` hint, streams 24 kHz PCM audio, and explicitly
-commits the turn when recording stops. The delay setting trades partial-result
-latency for transcription accuracy.
+For GPT Transcribe, hyprwhspr sends the configured scalar `language` as OpenAI's single-entry `languages` hint, streams
+24 kHz PCM audio, and explicitly commits the turn when recording stops. Transcription begins after that commit; any
+deltas arrive while OpenAI processes the committed turn, not while you are still speaking.
 
-Its `prompt` uses the existing active-language fallback: `whisper_prompt_<language>` → `whisper_prompt` → omitted.
+GPT Transcribe and GPT Live Transcribe both use the existing active-language prompt fallback:
+`whisper_prompt_<language>` → `whisper_prompt` → omitted. GPT Live Transcribe emits continuous live deltas and supports
+`realtime_transcription_delay`, which trades partial-result latency for final transcription accuracy. GPT Realtime
+Whisper remains available for legacy configurations.
 
 #### Google Gemini
 

--- a/lib/src/backends/realtime_ws_backend.py
+++ b/lib/src/backends/realtime_ws_backend.py
@@ -19,19 +19,23 @@ np = require_package('numpy')
 try:
     from ..backend_utils import normalize_backend
     from ..credential_manager import get_credential
+    from ..openai_realtime_models import (
+        OPENAI_CONTINUOUS_TRANSCRIPTION_MODELS,
+        OPENAI_LANGUAGE_CONTEXT_MODELS,
+        OPENAI_TRANSCRIPTION_ONLY_MODELS,
+    )
     from ..provider_registry import get_provider
 except ImportError:
     from backend_utils import normalize_backend
     from credential_manager import get_credential
+    from openai_realtime_models import (
+        OPENAI_CONTINUOUS_TRANSCRIPTION_MODELS,
+        OPENAI_LANGUAGE_CONTEXT_MODELS,
+        OPENAI_TRANSCRIPTION_ONLY_MODELS,
+    )
     from provider_registry import get_provider
 
 from .base import TranscriptionBackend
-
-
-OPENAI_STREAMING_TRANSCRIPTION_MODELS = frozenset({
-    'gpt-live-transcribe',
-    'gpt-realtime-whisper',
-})
 
 
 class RealtimeWsBackend(TranscriptionBackend):
@@ -67,12 +71,12 @@ class RealtimeWsBackend(TranscriptionBackend):
         language: Optional[str],
         model_id: Optional[str] = None,
     ) -> None:
-        """Keep GPT Live Transcribe's language hint and prompt in sync."""
+        """Keep new-model transcription language hints and prompts in sync."""
         if not self._realtime_client:
             return
 
         active_model = model_id or getattr(self._realtime_client, 'model', None)
-        if active_model == 'gpt-live-transcribe':
+        if active_model in OPENAI_LANGUAGE_CONTEXT_MODELS:
             self._realtime_client.update_transcription_config(
                 language,
                 self._resolve_whisper_prompt(language),
@@ -228,7 +232,7 @@ class RealtimeWsBackend(TranscriptionBackend):
             realtime_mode = self.config.get_setting('realtime_mode', 'transcribe')
             if (
                 provider_id == 'openai'
-                and model_id in OPENAI_STREAMING_TRANSCRIPTION_MODELS
+                and model_id in OPENAI_TRANSCRIPTION_ONLY_MODELS
                 and realtime_mode != 'transcribe'
             ):
                 print(
@@ -473,9 +477,9 @@ class RealtimeWsBackend(TranscriptionBackend):
                 and self.config.get_setting('mic_osd_pill_transcript_enabled', False)
             )
 
-        # Waveform: OpenAI's streaming transcription models emit live deltas.
+        # Waveform: only continuously streaming OpenAI models emit live deltas.
         if provider_id == 'openai':
-            return model_id in OPENAI_STREAMING_TRANSCRIPTION_MODELS
+            return model_id in OPENAI_CONTINUOUS_TRANSCRIPTION_MODELS
 
         return False
 

--- a/lib/src/backends/realtime_ws_backend.py
+++ b/lib/src/backends/realtime_ws_backend.py
@@ -20,18 +20,18 @@ try:
     from ..backend_utils import normalize_backend
     from ..credential_manager import get_credential
     from ..openai_realtime_models import (
-        OPENAI_CONTINUOUS_TRANSCRIPTION_MODELS,
-        OPENAI_LANGUAGE_CONTEXT_MODELS,
-        OPENAI_TRANSCRIPTION_ONLY_MODELS,
+        is_continuous,
+        is_transcription_only,
+        uses_language_context,
     )
     from ..provider_registry import get_provider
 except ImportError:
     from backend_utils import normalize_backend
     from credential_manager import get_credential
     from openai_realtime_models import (
-        OPENAI_CONTINUOUS_TRANSCRIPTION_MODELS,
-        OPENAI_LANGUAGE_CONTEXT_MODELS,
-        OPENAI_TRANSCRIPTION_ONLY_MODELS,
+        is_continuous,
+        is_transcription_only,
+        uses_language_context,
     )
     from provider_registry import get_provider
 
@@ -76,7 +76,7 @@ class RealtimeWsBackend(TranscriptionBackend):
             return
 
         active_model = model_id or getattr(self._realtime_client, 'model', None)
-        if active_model in OPENAI_LANGUAGE_CONTEXT_MODELS:
+        if uses_language_context(active_model):
             self._realtime_client.update_transcription_config(
                 language,
                 self._resolve_whisper_prompt(language),
@@ -232,7 +232,7 @@ class RealtimeWsBackend(TranscriptionBackend):
             realtime_mode = self.config.get_setting('realtime_mode', 'transcribe')
             if (
                 provider_id == 'openai'
-                and model_id in OPENAI_TRANSCRIPTION_ONLY_MODELS
+                and is_transcription_only(model_id)
                 and realtime_mode != 'transcribe'
             ):
                 print(
@@ -479,7 +479,7 @@ class RealtimeWsBackend(TranscriptionBackend):
 
         # Waveform: only continuously streaming OpenAI models emit live deltas.
         if provider_id == 'openai':
-            return model_id in OPENAI_CONTINUOUS_TRANSCRIPTION_MODELS
+            return is_continuous(model_id)
 
         return False
 

--- a/lib/src/cli/setup.py
+++ b/lib/src/cli/setup.py
@@ -37,13 +37,13 @@ except ImportError:
 
 try:
     from ..provider_registry import (
-        PROVIDERS, get_provider, list_providers, get_provider_models,
-        get_model_config, validate_api_key
+        PROVIDERS, get_provider, list_providers, get_model_config,
+        validate_api_key, get_models_for_backend, get_realtime_mode
     )
 except ImportError:
     from provider_registry import (
-        PROVIDERS, get_provider, list_providers, get_provider_models,
-        get_model_config, validate_api_key
+        PROVIDERS, get_provider, list_providers, get_model_config,
+        validate_api_key, get_models_for_backend, get_realtime_mode
     )
 
 try:
@@ -325,9 +325,7 @@ def _prompt_realtime_provider_model_selection():
         if not provider.get('websocket_endpoint'):
             continue
 
-        for model_id, model_data in provider.get('models', {}).items():
-            if not model_data.get('realtime_model', False):
-                continue
+        for model_id, model_data in get_models_for_backend(provider_id, 'realtime-ws').items():
             realtime_options.append((provider_id, provider, model_id, model_data))
             print(
                 f"  [{len(realtime_options)}] "
@@ -446,25 +444,14 @@ def _prompt_remote_provider_selection(filter_realtime: bool = False):
                 continue
 
             # Only show providers that have realtime-capable models
-            models = get_provider_models(provider_id) or {}
-            realtime_model_ids = [
-                model_id
-                for model_id, model_data in models.items()
-                if model_data.get('realtime_model', False)
-            ]
+            realtime_model_ids = list(get_models_for_backend(provider_id, 'realtime-ws'))
             if realtime_model_ids:
                 providers_list.append((provider_id, provider_name, realtime_model_ids))
     else:
-        # REST providers: only include providers with at least one REST-visible model
-        # (i.e. not marked hidden in provider_registry)
+        # REST providers: only include providers offering at least one REST model
         providers_list = []
         for provider_id, provider_name, _model_ids in all_providers_list:
-            models = get_provider_models(provider_id) or {}
-            visible_model_ids = [
-                model_id
-                for model_id, model_data in models.items()
-                if not model_data.get('hidden', False)
-            ]
+            visible_model_ids = list(get_models_for_backend(provider_id, 'rest-api'))
             if visible_model_ids:
                 providers_list.append((provider_id, provider_name, visible_model_ids))
     
@@ -498,19 +485,10 @@ def _prompt_remote_provider_selection(filter_realtime: bool = False):
                 print("="*60)
                 print()
                 
-                models = get_provider_models(provider_id)
+                backend = 'realtime-ws' if filter_realtime else 'rest-api'
                 model_list = []
-                
-                # Filter models based on backend type
-                for model_id, model_data in models.items():
-                    if filter_realtime:
-                        # Only include realtime models (marked with realtime_model flag)
-                        if not model_data.get('realtime_model', False):
-                            continue
-                    else:
-                        # For REST API, hide models marked as hidden
-                        if model_data.get('hidden', False):
-                            continue
+
+                for model_id, model_data in get_models_for_backend(provider_id, backend).items():
                     model_list.append((model_id, model_data))
                     print(f"  [{len(model_list)}] {model_data['name']} - {model_data['description']}")
                 
@@ -956,8 +934,12 @@ def setup_command(python_path: Optional[str] = None):
             log_error(f"Failed to generate realtime configuration: {e}")
             return
         
-        remote_config['realtime_mode'] = 'transcribe'
-        log_info("Realtime mode: transcribe")
+        realtime_mode = get_realtime_mode(provider_id, model_id)
+        remote_config['realtime_mode'] = realtime_mode
+        if realtime_mode == 'converse':
+            log_info("Realtime mode: converse (spoken AI replies)")
+        else:
+            log_info("Realtime mode: transcribe (speech-to-text)")
     
     # Step 1.4: Ensure venv and base dependencies for cloud backends
     if backend_normalized in ['rest-api', 'remote', 'realtime-ws']:

--- a/lib/src/cli/setup.py
+++ b/lib/src/cli/setup.py
@@ -317,7 +317,7 @@ def _prompt_realtime_provider_model_selection():
     print("\n" + "="*60)
     print("Realtime Provider and Model Selection")
     print("="*60)
-    print("\nChoose a realtime streaming provider and model:")
+    print("\nChoose a realtime WebSocket provider and model:")
     print()
 
     realtime_options = []

--- a/lib/src/config_manager.py
+++ b/lib/src/config_manager.py
@@ -132,7 +132,7 @@ class ConfigManager:
             'realtime_buffer_max_seconds': 5,  # Max buffer before dropping chunks
             'realtime_mode': 'transcribe',      # 'transcribe' (speech-to-text) or 'converse' (voice-to-AI)
             'realtime_transcription_delay': 'low',  # OpenAI continuous transcription delay: minimal|low|medium|high|xhigh
-            'realtime_conversation_history': 'session',  # OpenAI converse mode: session|turn
+            'realtime_conversation_history': 'turn',  # OpenAI converse mode: session|turn
             # whisper.cpp (pywhispercpp) backend settings
             'pywhispercpp_use_vad': False,               # Native Silero VAD (strips silence, reduces hallucinations); auto-downloads ~1MB ggml-silero model when enabled
             # ONNX-ASR backend settings (CPU-optimized)

--- a/lib/src/config_manager.py
+++ b/lib/src/config_manager.py
@@ -126,12 +126,12 @@ class ConfigManager:
             'rest_audio_format': 'wav',        # Audio format for remote transcription
             # WebSocket realtime backend settings
             'websocket_provider': None,        # Provider identifier for credential lookup (e.g., 'openai', 'google', 'elevenlabs')
-            'websocket_model': None,           # Model identifier (e.g., 'gpt-live-transcribe')
+            'websocket_model': None,           # Model identifier (e.g., 'gpt-transcribe')
             'websocket_url': None,             # Optional: explicit WebSocket URL (auto-derived if None)
             'realtime_timeout': 30,            # Completion timeout (seconds)
             'realtime_buffer_max_seconds': 5,  # Max buffer before dropping chunks
             'realtime_mode': 'transcribe',      # 'transcribe' (speech-to-text) or 'converse' (voice-to-AI)
-            'realtime_transcription_delay': 'low',  # OpenAI streaming delay: minimal|low|medium|high|xhigh
+            'realtime_transcription_delay': 'low',  # OpenAI continuous transcription delay: minimal|low|medium|high|xhigh
             'realtime_conversation_history': 'session',  # OpenAI converse mode: session|turn
             # whisper.cpp (pywhispercpp) backend settings
             'pywhispercpp_use_vad': False,               # Native Silero VAD (strips silence, reduces hallucinations); auto-downloads ~1MB ggml-silero model when enabled

--- a/lib/src/openai_realtime_models.py
+++ b/lib/src/openai_realtime_models.py
@@ -1,26 +1,37 @@
-"""Capabilities for OpenAI transcription models used over Realtime WebSocket."""
+"""Capabilities for OpenAI transcription models used over Realtime WebSocket.
+
+Capabilities live on the model entries in provider_registry so a model is
+described in one place. Unknown models (custom endpoints) report no
+capabilities, which keeps them on server VAD and the singular `language` field.
+"""
+
+try:
+    from .provider_registry import get_realtime_capabilities
+except ImportError:
+    from provider_registry import get_realtime_capabilities
 
 
-OPENAI_TRANSCRIPTION_ONLY_MODELS = frozenset({
-    'gpt-transcribe',
-    'gpt-live-transcribe',
-    'gpt-realtime-whisper',
-})
+def _capability(model_id, name):
+    if not model_id:
+        return False
+    return bool(get_realtime_capabilities('openai', model_id).get(name))
 
-OPENAI_MANUAL_COMMIT_MODELS = frozenset({
-    'gpt-transcribe',
-    'gpt-live-transcribe',
-    'gpt-realtime-whisper',
-})
 
-OPENAI_LANGUAGE_CONTEXT_MODELS = frozenset({
-    'gpt-transcribe',
-    'gpt-live-transcribe',
-})
+def is_transcription_only(model_id) -> bool:
+    """The model rejects realtime_mode="converse"."""
+    return _capability(model_id, 'transcription_only')
 
-# These models can emit transcript text while audio is still arriving. Keep
-# delay configuration and continuous waveform previews limited to this group.
-OPENAI_CONTINUOUS_TRANSCRIPTION_MODELS = frozenset({
-    'gpt-live-transcribe',
-    'gpt-realtime-whisper',
-})
+
+def uses_manual_commit(model_id) -> bool:
+    """The session disables server VAD and commits the turn on stop."""
+    return _capability(model_id, 'manual_commit')
+
+
+def uses_language_context(model_id) -> bool:
+    """The model takes a `languages` array and an optional `prompt`."""
+    return _capability(model_id, 'language_context')
+
+
+def is_continuous(model_id) -> bool:
+    """The model emits transcript deltas while audio is still arriving."""
+    return _capability(model_id, 'continuous')

--- a/lib/src/openai_realtime_models.py
+++ b/lib/src/openai_realtime_models.py
@@ -1,0 +1,26 @@
+"""Capabilities for OpenAI transcription models used over Realtime WebSocket."""
+
+
+OPENAI_TRANSCRIPTION_ONLY_MODELS = frozenset({
+    'gpt-transcribe',
+    'gpt-live-transcribe',
+    'gpt-realtime-whisper',
+})
+
+OPENAI_MANUAL_COMMIT_MODELS = frozenset({
+    'gpt-transcribe',
+    'gpt-live-transcribe',
+    'gpt-realtime-whisper',
+})
+
+OPENAI_LANGUAGE_CONTEXT_MODELS = frozenset({
+    'gpt-transcribe',
+    'gpt-live-transcribe',
+})
+
+# These models can emit transcript text while audio is still arriving. Keep
+# delay configuration and continuous waveform previews limited to this group.
+OPENAI_CONTINUOUS_TRANSCRIPTION_MODELS = frozenset({
+    'gpt-live-transcribe',
+    'gpt-realtime-whisper',
+})

--- a/lib/src/provider_registry.py
+++ b/lib/src/provider_registry.py
@@ -17,6 +17,13 @@ PROVIDERS: Dict[str, Dict] = {
         'api_key_prefix': 'sk-',
         'api_key_description': 'OpenAI API key (starts with sk-)',
         'models': {
+            'gpt-transcribe': {
+                'name': 'GPT Transcribe',
+                'description': 'Recommended: accurate, fast, inexpensive committed-turn transcription',
+                'body': {'model': 'gpt-transcribe'},
+                'realtime_model': True,
+                'hidden': True
+            },
             'gpt-live-transcribe': {
                 'name': 'GPT Live Transcribe',
                 'description': 'Live streaming with the best OSD previews; higher cost',

--- a/lib/src/provider_registry.py
+++ b/lib/src/provider_registry.py
@@ -6,9 +6,14 @@ Defines known providers, their models, and configuration templates
 from typing import Dict, List, Optional, Tuple
 
 
-# Provider registry with known cloud transcription providers
-# Model entries marked hidden stay out of the REST setup model list while
-# remaining selectable for provider-specific realtime setup flows.
+DEFAULT_MODEL_BACKENDS: Tuple[str, ...] = ('rest-api',)
+
+
+# Provider registry with known cloud transcription providers.
+#
+# 'backends' lists which setup pickers offer a model; it defaults to
+# DEFAULT_MODEL_BACKENDS when omitted. 'realtime' carries the model's Realtime
+# WebSocket capabilities, which drive session payloads and mode guards.
 PROVIDERS: Dict[str, Dict] = {
     'openai': {
         'name': 'OpenAI',
@@ -19,17 +24,51 @@ PROVIDERS: Dict[str, Dict] = {
         'models': {
             'gpt-transcribe': {
                 'name': 'GPT Transcribe',
-                'description': 'Recommended: accurate, fast, inexpensive committed-turn transcription',
-                'body': {'model': 'gpt-transcribe'},
-                'realtime_model': True,
-                'hidden': True
+                'description': 'Recommended: accurate, fast, and inexpensive',
+                'backends': ('realtime-ws',),
+                'realtime': {
+                    'default_mode': 'transcribe',
+                    'transcription_only': True,
+                    'manual_commit': True,
+                    'language_context': True,
+                    'continuous': False,
+                },
             },
             'gpt-live-transcribe': {
                 'name': 'GPT Live Transcribe',
                 'description': 'Live streaming with the best OSD previews; higher cost',
-                'body': {'model': 'gpt-live-transcribe'},
-                'realtime_model': True,
-                'hidden': True
+                'backends': ('realtime-ws',),
+                'realtime': {
+                    'default_mode': 'transcribe',
+                    'transcription_only': True,
+                    'manual_commit': True,
+                    'language_context': True,
+                    'continuous': True,
+                },
+            },
+            'gpt-realtime-whisper': {
+                'name': 'GPT Realtime Whisper',
+                'description': 'Legacy realtime streaming transcription model',
+                'backends': ('realtime-ws',),
+                'realtime': {
+                    'default_mode': 'transcribe',
+                    'transcription_only': True,
+                    'manual_commit': True,
+                    'language_context': False,
+                    'continuous': True,
+                },
+            },
+            'gpt-realtime-2.1': {
+                'name': 'GPT-Realtime-2.1',
+                'description': 'Voice-to-AI: speak and get spoken replies',
+                'backends': ('realtime-ws',),
+                'realtime': {'default_mode': 'converse'},
+            },
+            'gpt-realtime-2.1-mini': {
+                'name': 'GPT-Realtime-2.1 mini',
+                'description': 'Voice-to-AI, cost-efficient',
+                'backends': ('realtime-ws',),
+                'realtime': {'default_mode': 'converse'},
             },
             'gpt-4o-transcribe': {
                 'name': 'GPT-4o Transcribe',
@@ -45,13 +84,6 @@ PROVIDERS: Dict[str, Dict] = {
                 'name': 'GPT-4o Mini Transcribe (2025-12-15)',
                 'description': 'Updated version of the faster, lighter transcription model',
                 'body': {'model': 'gpt-4o-mini-transcribe-2025-12-15'}
-            },
-            'gpt-realtime-whisper': {
-                'name': 'GPT Realtime Whisper',
-                'description': 'Legacy realtime streaming transcription model',
-                'body': {'model': 'gpt-realtime-whisper'},
-                'realtime_model': True,
-                'hidden': True
             },
             'gpt-audio-mini-2025-12-15': {
                 'name': 'GPT Audio Mini (2025-12-15)',
@@ -119,16 +151,14 @@ PROVIDERS: Dict[str, Dict] = {
             'gemini-3.1-flash-live-preview': {
                 'name': 'Gemini 3.1 Flash Live (Preview)',
                 'description': 'Fast, low-latency realtime streaming',
-                'body': {'model': 'gemini-3.1-flash-live-preview'},
-                'realtime_model': True,
-                'hidden': True
+                'backends': ('realtime-ws',),
+                'realtime': {'default_mode': 'transcribe'},
             },
-            'gemini-2.5-flash-native-audio-latest': {
-                'name': 'Gemini 2.5 Flash Native Audio',
-                'description': 'Native audio understanding, stable release',
-                'body': {'model': 'gemini-2.5-flash-native-audio-latest'},
-                'realtime_model': True,
-                'hidden': True
+            'gemini-2.5-flash-native-audio-preview-12-2025': {
+                'name': 'Gemini 2.5 Flash Native Audio (Preview)',
+                'description': 'Native audio, sub-second conversational streaming',
+                'backends': ('realtime-ws',),
+                'realtime': {'default_mode': 'transcribe'},
             },
         }
     },
@@ -144,14 +174,13 @@ PROVIDERS: Dict[str, Dict] = {
                 'name': 'Scribe v2',
                 'description': 'Batch transcription, 90+ languages',
                 'body': {'model_id': 'scribe_v2'},
-                'hidden': True
+                'backends': (),  # reference entry; no setup picker offers it
             },
             'scribe_v2_realtime': {
                 'name': 'Scribe v2 Realtime',
                 'description': 'Ultra-low latency (~150ms), 90+ languages',
-                'body': {'model_id': 'scribe_v2_realtime'},
-                'realtime_model': True,
-                'hidden': True
+                'backends': ('realtime-ws',),
+                'realtime': {'default_mode': 'transcribe'},
             }
         }
     }
@@ -183,6 +212,34 @@ def get_provider_models(provider_id: str) -> Optional[Dict[str, Dict]]:
     if provider:
         return provider.get('models')
     return None
+
+
+def model_backends(model_data: Dict) -> Tuple[str, ...]:
+    """Backends whose setup picker offers this model."""
+    return tuple(model_data.get('backends', DEFAULT_MODEL_BACKENDS))
+
+
+def get_models_for_backend(provider_id: str, backend: str) -> Dict[str, Dict]:
+    """Models a provider offers for the given transcription backend."""
+    models = get_provider_models(provider_id) or {}
+    return {
+        model_id: model_data
+        for model_id, model_data in models.items()
+        if backend in model_backends(model_data)
+    }
+
+
+def get_realtime_capabilities(provider_id: str, model_id: str) -> Dict:
+    """Realtime WebSocket capabilities for a model, empty when unknown."""
+    models = get_provider_models(provider_id) or {}
+    return (models.get(model_id) or {}).get('realtime') or {}
+
+
+def get_realtime_mode(provider_id: str, model_id: str) -> str:
+    """Mode a model expects: 'transcribe' or 'converse'."""
+    return get_realtime_capabilities(provider_id, model_id).get(
+        'default_mode', 'transcribe'
+    )
 
 
 def get_model_config(provider_id: str, model_id: str) -> Optional[Dict]:

--- a/lib/src/realtime_client.py
+++ b/lib/src/realtime_client.py
@@ -41,7 +41,7 @@ class RealtimeClient(WebSocketRealtimeClientBase):
         super().__init__(mode=mode)
         self.transcription_delay = 'low'
         self.transcription_prompt = None
-        self.conversation_history = 'session'
+        self.conversation_history = 'turn'
         self.partial_transcript_callback = None
         self.sample_rate = 24000  # OpenAI Realtime API requires 24kHz
 
@@ -366,10 +366,10 @@ class RealtimeClient(WebSocketRealtimeClientBase):
 
     def set_conversation_history(self, history: str):
         """Set whether conversational turns retain server-side history."""
-        history = (history or 'session').strip().lower()
+        history = (history or 'turn').strip().lower()
         if history not in self.VALID_CONVERSATION_HISTORY:
-            self._log(f"Invalid realtime_conversation_history '{history}', using 'session'")
-            history = 'session'
+            self._log(f"Invalid realtime_conversation_history '{history}', using 'turn'")
+            history = 'turn'
         self.conversation_history = history
 
     def set_partial_transcript_callback(self, callback):

--- a/lib/src/realtime_client.py
+++ b/lib/src/realtime_client.py
@@ -10,16 +10,16 @@ from typing import Optional
 
 try:
     from .openai_realtime_models import (
-        OPENAI_CONTINUOUS_TRANSCRIPTION_MODELS,
-        OPENAI_LANGUAGE_CONTEXT_MODELS,
-        OPENAI_MANUAL_COMMIT_MODELS,
+        is_continuous,
+        uses_language_context,
+        uses_manual_commit,
     )
     from .realtime_base import WebSocketRealtimeClientBase
 except ImportError:
     from openai_realtime_models import (
-        OPENAI_CONTINUOUS_TRANSCRIPTION_MODELS,
-        OPENAI_LANGUAGE_CONTEXT_MODELS,
-        OPENAI_MANUAL_COMMIT_MODELS,
+        is_continuous,
+        uses_language_context,
+        uses_manual_commit,
     )
     from realtime_base import WebSocketRealtimeClientBase
 
@@ -279,17 +279,17 @@ class RealtimeClient(WebSocketRealtimeClientBase):
             model = self.model or 'gpt-4o-mini-transcribe'
             transcription_config = {'model': model}
 
-            uses_language_context = model in OPENAI_LANGUAGE_CONTEXT_MODELS
+            language_context = uses_language_context(model)
             if self.language:
-                if uses_language_context:
+                if language_context:
                     transcription_config['languages'] = [self.language]
                 else:
                     transcription_config['language'] = self.language
 
-            if uses_language_context and self.transcription_prompt:
+            if language_context and self.transcription_prompt:
                 transcription_config['prompt'] = self.transcription_prompt
 
-            if model in OPENAI_CONTINUOUS_TRANSCRIPTION_MODELS:
+            if is_continuous(model):
                 transcription_config['delay'] = self._validated_transcription_delay()
 
             session_data = {
@@ -301,7 +301,7 @@ class RealtimeClient(WebSocketRealtimeClientBase):
                             'rate': 24000
                         },
                         'transcription': transcription_config,
-                        'turn_detection': None if model in OPENAI_MANUAL_COMMIT_MODELS else {
+                        'turn_detection': None if uses_manual_commit(model) else {
                             'type': 'server_vad',
                             'threshold': 0.5,
                             'prefix_padding_ms': 300,

--- a/lib/src/realtime_client.py
+++ b/lib/src/realtime_client.py
@@ -9,8 +9,18 @@ from collections import deque
 from typing import Optional
 
 try:
+    from .openai_realtime_models import (
+        OPENAI_CONTINUOUS_TRANSCRIPTION_MODELS,
+        OPENAI_LANGUAGE_CONTEXT_MODELS,
+        OPENAI_MANUAL_COMMIT_MODELS,
+    )
     from .realtime_base import WebSocketRealtimeClientBase
 except ImportError:
+    from openai_realtime_models import (
+        OPENAI_CONTINUOUS_TRANSCRIPTION_MODELS,
+        OPENAI_LANGUAGE_CONTEXT_MODELS,
+        OPENAI_MANUAL_COMMIT_MODELS,
+    )
     from realtime_base import WebSocketRealtimeClientBase
 
 
@@ -269,19 +279,17 @@ class RealtimeClient(WebSocketRealtimeClientBase):
             model = self.model or 'gpt-4o-mini-transcribe'
             transcription_config = {'model': model}
 
-            is_live_transcribe = model == 'gpt-live-transcribe'
+            uses_language_context = model in OPENAI_LANGUAGE_CONTEXT_MODELS
             if self.language:
-                if is_live_transcribe:
+                if uses_language_context:
                     transcription_config['languages'] = [self.language]
                 else:
                     transcription_config['language'] = self.language
 
-            if is_live_transcribe and self.transcription_prompt:
+            if uses_language_context and self.transcription_prompt:
                 transcription_config['prompt'] = self.transcription_prompt
 
-            is_realtime_whisper = model == 'gpt-realtime-whisper'
-            is_streaming_transcription = is_realtime_whisper or is_live_transcribe
-            if is_streaming_transcription:
+            if model in OPENAI_CONTINUOUS_TRANSCRIPTION_MODELS:
                 transcription_config['delay'] = self._validated_transcription_delay()
 
             session_data = {
@@ -293,7 +301,7 @@ class RealtimeClient(WebSocketRealtimeClientBase):
                             'rate': 24000
                         },
                         'transcription': transcription_config,
-                        'turn_detection': None if is_streaming_transcription else {
+                        'turn_detection': None if model in OPENAI_MANUAL_COMMIT_MODELS else {
                             'type': 'server_vad',
                             'threshold': 0.5,
                             'prefix_padding_ms': 300,
@@ -336,7 +344,7 @@ class RealtimeClient(WebSocketRealtimeClientBase):
         language: Optional[str],
         prompt: Optional[str],
     ):
-        """Update GPT Live Transcribe language and prompt together."""
+        """Update new-model transcription language and prompt together."""
         self.language = language
         self.transcription_prompt = prompt
         if self.connected:

--- a/share/config.schema.json
+++ b/share/config.schema.json
@@ -320,7 +320,7 @@
     "realtime_conversation_history": {
       "type": "string",
       "enum": ["session", "turn"],
-      "default": "session",
+      "default": "turn",
       "description": "OpenAI Realtime converse history: retain the session or delete completed turns"
     },
     "pywhispercpp_use_vad": {

--- a/share/config.schema.json
+++ b/share/config.schema.json
@@ -286,7 +286,7 @@
     "websocket_model": {
       "type": ["string", "null"],
       "default": null,
-      "description": "Model identifier for WebSocket backend (e.g., 'gpt-live-transcribe', 'gemini-3.1-flash-live-preview')"
+      "description": "Model identifier for WebSocket backend (e.g., 'gpt-transcribe', 'gemini-3.1-flash-live-preview')"
     },
     "websocket_url": {
       "type": ["string", "null"],
@@ -315,7 +315,7 @@
       "type": "string",
       "enum": ["minimal", "low", "medium", "high", "xhigh"],
       "default": "low",
-      "description": "Latency/accuracy delay setting for OpenAI streaming transcription models"
+      "description": "Latency/accuracy delay setting for OpenAI continuous transcription models"
     },
     "realtime_conversation_history": {
       "type": "string",

--- a/tests/test_config_schema_sync.py
+++ b/tests/test_config_schema_sync.py
@@ -65,6 +65,19 @@ class ConfigSchemaSyncTests(unittest.TestCase):
                 json_type = "number"
             self.assertIn(json_type, accepted, key)
 
+    def test_realtime_client_conversation_history_default_matches_schema(self):
+        # RealtimeClient carries its own fallback, so a schema-only change would
+        # otherwise ship green while the client kept the previous behaviour.
+        sys.path.insert(0, str(ROOT / "lib" / "src"))
+        from realtime_client import RealtimeClient
+
+        expected = self.schema_properties["realtime_conversation_history"]["default"]
+        self.assertEqual(RealtimeClient(mode="converse").conversation_history, expected)
+
+        client = RealtimeClient(mode="converse")
+        client.set_conversation_history("nonsense")
+        self.assertEqual(client.conversation_history, expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_elevenlabs_pill_preview.py
+++ b/tests/test_elevenlabs_pill_preview.py
@@ -167,6 +167,18 @@ class ElevenLabsRealtimePreviewTests(unittest.TestCase):
 
         self.assertIsNotNone(self.client.callback)
 
+    def test_gpt_transcribe_preview_is_not_enabled_for_waveform(self):
+        self.manager.config.values.update({
+            "websocket_provider": "openai",
+            "websocket_model": "gpt-transcribe",
+            "mic_osd_style": "waveform",
+        })
+
+        previews = self._apply()
+
+        self.assertIsNone(self.client.callback)
+        self.assertEqual(previews, [""])
+
     def test_openai_preview_is_also_shown_in_pill(self):
         self.manager.config.values.update({
             "websocket_provider": "openai",
@@ -207,21 +219,27 @@ class ElevenLabsRealtimePreviewTests(unittest.TestCase):
 
 
 class OpenAIRealtimeModeTests(unittest.TestCase):
-    def test_gpt_live_transcribe_rejects_converse_mode(self):
-        config = FakeConfig({
-            "websocket_provider": "openai",
-            "websocket_model": "gpt-live-transcribe",
-            "realtime_mode": "converse",
-        })
-        backend = RealtimeWsBackend(FakeManager(config))
-
-        with mock.patch(
-            "backends.realtime_ws_backend.get_credential",
-            return_value="sk-test-openai-key",
+    def test_dedicated_transcription_models_reject_converse_mode(self):
+        for model in (
+            "gpt-transcribe",
+            "gpt-live-transcribe",
+            "gpt-realtime-whisper",
         ):
-            self.assertFalse(backend.initialize())
+            with self.subTest(model=model):
+                config = FakeConfig({
+                    "websocket_provider": "openai",
+                    "websocket_model": model,
+                    "realtime_mode": "converse",
+                })
+                backend = RealtimeWsBackend(FakeManager(config))
 
-        self.assertIsNone(backend._realtime_client)
+                with mock.patch(
+                    "backends.realtime_ws_backend.get_credential",
+                    return_value="sk-test-openai-key",
+                ):
+                    self.assertFalse(backend.initialize())
+
+                self.assertIsNone(backend._realtime_client)
 
 
 class OpenAIRealtimePromptTests(unittest.TestCase):
@@ -251,25 +269,26 @@ class OpenAIRealtimePromptTests(unittest.TestCase):
             ("omitted", {"whisper_prompt": ""}, None),
         )
 
-        for name, prompt_config, expected_prompt in cases:
-            with self.subTest(name=name):
-                config = FakeConfig({
-                    "websocket_provider": "openai",
-                    "websocket_model": "gpt-live-transcribe",
-                    **prompt_config,
-                })
-                backend = RealtimeWsBackend(FakeManager(config))
-                client = mock.Mock()
-                client.model = "gpt-live-transcribe"
-                backend._realtime_client = client
+        for model in ("gpt-transcribe", "gpt-live-transcribe"):
+            for name, prompt_config, expected_prompt in cases:
+                with self.subTest(model=model, name=name):
+                    config = FakeConfig({
+                        "websocket_provider": "openai",
+                        "websocket_model": model,
+                        **prompt_config,
+                    })
+                    backend = RealtimeWsBackend(FakeManager(config))
+                    client = mock.Mock()
+                    client.model = model
+                    backend._realtime_client = client
 
-                backend.update_language("de")
+                    backend.update_language("de")
 
-                client.update_transcription_config.assert_called_once_with(
-                    "de",
-                    expected_prompt,
-                )
-                client.update_language.assert_not_called()
+                    client.update_transcription_config.assert_called_once_with(
+                        "de",
+                        expected_prompt,
+                    )
+                    client.update_language.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_provider_registry_capabilities.py
+++ b/tests/test_provider_registry_capabilities.py
@@ -1,0 +1,97 @@
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "lib" / "src"))
+
+import openai_realtime_models as caps  # noqa: E402
+from provider_registry import (  # noqa: E402
+    PROVIDERS,
+    get_models_for_backend,
+    get_realtime_mode,
+    model_backends,
+)
+
+
+class ModelBackendRoutingTests(unittest.TestCase):
+    """Every model declares which setup picker offers it, in one place."""
+
+    def test_models_default_to_the_rest_picker(self):
+        self.assertEqual(model_backends({}), ("rest-api",))
+
+    def test_realtime_models_stay_out_of_the_rest_picker(self):
+        rest_models = get_models_for_backend("openai", "rest-api")
+        for model_id in ("gpt-transcribe", "gpt-live-transcribe", "gpt-realtime-2.1"):
+            self.assertNotIn(model_id, rest_models)
+
+    def test_rest_models_stay_out_of_the_realtime_picker(self):
+        realtime_models = get_models_for_backend("openai", "realtime-ws")
+        for model_id in ("whisper-1", "gpt-4o-transcribe"):
+            self.assertNotIn(model_id, realtime_models)
+
+    def test_elevenlabs_offers_only_its_realtime_model(self):
+        self.assertEqual(list(get_models_for_backend("elevenlabs", "rest-api")), [])
+        self.assertEqual(
+            list(get_models_for_backend("elevenlabs", "realtime-ws")),
+            ["scribe_v2_realtime"],
+        )
+
+    def test_every_realtime_model_declares_capabilities(self):
+        # A realtime model without a 'realtime' block would silently fall back to
+        # server VAD and the singular language field.
+        for provider_id in PROVIDERS:
+            for model_id, model_data in get_models_for_backend(
+                provider_id, "realtime-ws"
+            ).items():
+                self.assertIn("realtime", model_data, f"{provider_id}/{model_id}")
+
+
+class RealtimeModeTests(unittest.TestCase):
+    def test_transcription_models_default_to_transcribe(self):
+        for model_id in (
+            "gpt-transcribe",
+            "gpt-live-transcribe",
+            "gpt-realtime-whisper",
+        ):
+            self.assertEqual(get_realtime_mode("openai", model_id), "transcribe")
+
+    def test_conversational_models_default_to_converse(self):
+        for model_id in ("gpt-realtime-2.1", "gpt-realtime-2.1-mini"):
+            self.assertEqual(get_realtime_mode("openai", model_id), "converse")
+
+    def test_unknown_and_custom_models_default_to_transcribe(self):
+        self.assertEqual(get_realtime_mode("custom", "qwen-audio-realtime"), "transcribe")
+        self.assertEqual(get_realtime_mode("openai", "not-a-model"), "transcribe")
+
+
+class TranscriptionCapabilityTests(unittest.TestCase):
+    def test_gpt_transcribe_commits_manually_without_live_deltas(self):
+        self.assertTrue(caps.is_transcription_only("gpt-transcribe"))
+        self.assertTrue(caps.uses_manual_commit("gpt-transcribe"))
+        self.assertTrue(caps.uses_language_context("gpt-transcribe"))
+        self.assertFalse(caps.is_continuous("gpt-transcribe"))
+
+    def test_live_transcribe_streams_deltas_continuously(self):
+        self.assertTrue(caps.uses_language_context("gpt-live-transcribe"))
+        self.assertTrue(caps.is_continuous("gpt-live-transcribe"))
+
+    def test_realtime_whisper_streams_without_language_context(self):
+        self.assertTrue(caps.is_continuous("gpt-realtime-whisper"))
+        self.assertFalse(caps.uses_language_context("gpt-realtime-whisper"))
+
+    def test_conversational_models_are_not_transcription_only(self):
+        self.assertFalse(caps.is_transcription_only("gpt-realtime-2.1"))
+        self.assertFalse(caps.uses_manual_commit("gpt-realtime-2.1"))
+
+    def test_unknown_models_report_no_capabilities(self):
+        # Custom endpoints keep server VAD and the singular language field.
+        for model_id in ("qwen-audio-3.0-realtime-plus", "", None):
+            self.assertFalse(caps.is_transcription_only(model_id))
+            self.assertFalse(caps.uses_manual_commit(model_id))
+            self.assertFalse(caps.uses_language_context(model_id))
+            self.assertFalse(caps.is_continuous(model_id))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_realtime_client.py
+++ b/tests/test_realtime_client.py
@@ -100,6 +100,51 @@ class RealtimeClientTests(unittest.TestCase):
             },
         )
 
+    def test_gpt_transcribe_session_payload(self):
+        client = self._client_with_ws("gpt-transcribe")
+        client.update_transcription_config(
+            "en",
+            "Linux and software-development dictation.",
+        )
+        client.set_transcription_delay("xhigh")
+        client.ws.sent.clear()
+
+        client._send_session_update()
+
+        self.assertEqual(
+            client.ws.sent[-1],
+            {
+                "type": "session.update",
+                "session": {
+                    "type": "transcription",
+                    "audio": {
+                        "input": {
+                            "format": {"type": "audio/pcm", "rate": 24000},
+                            "transcription": {
+                                "model": "gpt-transcribe",
+                                "languages": ["en"],
+                                "prompt": "Linux and software-development dictation.",
+                            },
+                            "turn_detection": None,
+                        }
+                    },
+                },
+            },
+        )
+
+    def test_gpt_transcribe_omits_unconfigured_context(self):
+        client = self._client_with_ws("gpt-transcribe")
+
+        client._send_session_update()
+
+        transcription = client.ws.sent[-1]["session"]["audio"]["input"]["transcription"]
+        self.assertEqual(transcription, {"model": "gpt-transcribe"})
+        self.assertNotIn("language", transcription)
+        self.assertNotIn("languages", transcription)
+        self.assertNotIn("prompt", transcription)
+        self.assertNotIn("keywords", transcription)
+        self.assertNotIn("delay", transcription)
+
     def test_gpt_live_transcribe_omits_unset_prompt(self):
         client = self._client_with_ws("gpt-live-transcribe")
 
@@ -320,6 +365,37 @@ class RealtimeClientTests(unittest.TestCase):
 
         self.assertEqual(previews, ["hello", "hello wor", ""])
         self.assertEqual(client.commit_and_get_text(timeout=0.1), "hello world")
+
+    def test_gpt_transcribe_commit_accepts_detected_languages_metadata(self):
+        for detected_languages in ([{"code": "fr"}], []):
+            with self.subTest(detected_languages=detected_languages):
+                client = self._client_with_ws("gpt-transcribe")
+
+                client._request_transcript({"buffer_was_committed": False})
+                client._handle_event({
+                    "type": "input_audio_buffer.committed",
+                    "item_id": "item_003",
+                })
+                client._handle_event({
+                    "type": "conversation.item.input_audio_transcription.delta",
+                    "item_id": "item_003",
+                    "delta": "Bonjour, ",
+                })
+                client._handle_event({
+                    "type": "conversation.item.input_audio_transcription.completed",
+                    "item_id": "item_003",
+                    "transcript": "Bonjour, pouvez-vous m'entendre ?",
+                    "languages": detected_languages,
+                })
+
+                self.assertEqual(
+                    client.commit_and_get_text(timeout=0.1),
+                    "Bonjour, pouvez-vous m'entendre ?",
+                )
+                self.assertEqual(
+                    client.ws.sent,
+                    [{"type": "input_audio_buffer.commit"}],
+                )
 
     def test_completed_without_transcript_uses_accumulated_delta_text(self):
         previews = []

--- a/tests/test_realtime_client.py
+++ b/tests/test_realtime_client.py
@@ -206,6 +206,7 @@ class RealtimeClientTests(unittest.TestCase):
         client = RealtimeClient(mode="converse")
         client.connected = True
         client.ws = FakeWebSocket()
+        client.set_conversation_history("session")
         client._handle_event({"type": "input_audio_buffer.committed", "item_id": "input_1"})
         client._request_transcript({"buffer_was_committed": True})
         request_id = client.ws.sent[-1]["response"]["metadata"]["hyprwhspr_request_id"]
@@ -221,6 +222,11 @@ class RealtimeClientTests(unittest.TestCase):
 
         self.assertEqual([event for event in client.ws.sent if event["type"] == "conversation.item.delete"], [])
         self.assertTrue(client.response_complete)
+
+    def test_converse_defaults_to_deleting_completed_turn_history(self):
+        client = RealtimeClient(mode="converse")
+
+        self.assertEqual(client.conversation_history, "turn")
 
     def test_converse_turn_history_deletes_completed_input_and_outputs(self):
         client = RealtimeClient(mode="converse")
@@ -465,7 +471,7 @@ class RealtimeClientTests(unittest.TestCase):
         schema = json.loads((ROOT / "share" / "config.schema.json").read_text())
         history_schema = schema["properties"]["realtime_conversation_history"]
 
-        self.assertEqual(history_schema["default"], "session")
+        self.assertEqual(history_schema["default"], "turn")
         self.assertEqual(history_schema["enum"], ["session", "turn"])
 
     def test_append_audio_uses_configured_input_sample_rate_for_duration(self):

--- a/tests/test_setup_command_scope.py
+++ b/tests/test_setup_command_scope.py
@@ -100,6 +100,49 @@ class SetupCommandScopeTests(unittest.TestCase):
         self.assertLess(live_position, whisper_position)
 
 
+class RealtimeSetupCatalogTests(unittest.TestCase):
+    def _catalog(self):
+        class SelectFirstPrompt:
+            @staticmethod
+            def ask(*_args, **_kwargs):
+                return "1"
+
+        class AcceptDefaultConfirm:
+            @staticmethod
+            def ask(*_args, **_kwargs):
+                return True
+
+        output = io.StringIO()
+        with (
+            mock.patch.object(setup, "Prompt", SelectFirstPrompt),
+            mock.patch.object(setup, "Confirm", AcceptDefaultConfirm),
+            mock.patch.object(setup, "get_credential", return_value="sk-existing-key"),
+            mock.patch.object(setup, "save_credential", return_value=True),
+            contextlib.redirect_stdout(output),
+        ):
+            setup._prompt_realtime_provider_model_selection()
+        return output.getvalue()
+
+    def test_transcription_models_are_listed_before_conversational_ones(self):
+        catalog = self._catalog()
+        last_transcription = catalog.index("OpenAI: GPT Realtime Whisper")
+        first_converse = catalog.index("OpenAI: GPT-Realtime-2.1")
+        self.assertLess(last_transcription, first_converse)
+
+    def test_rest_only_models_stay_out_of_the_realtime_catalog(self):
+        catalog = self._catalog()
+        self.assertNotIn("Whisper 1", catalog)
+        self.assertNotIn("GPT-4o Transcribe", catalog)
+
+    def test_selecting_a_conversational_model_configures_converse_mode(self):
+        self.assertEqual(
+            setup.get_realtime_mode("openai", "gpt-realtime-2.1"), "converse"
+        )
+        self.assertEqual(
+            setup.get_realtime_mode("openai", "gpt-transcribe"), "transcribe"
+        )
+
+
 class ConfigDefaultTests(unittest.TestCase):
     def test_defaults_match_schema_for_new_settings(self):
         with mock.patch.object(ConfigManager, "_ensure_config_dir"), \

--- a/tests/test_setup_command_scope.py
+++ b/tests/test_setup_command_scope.py
@@ -67,7 +67,7 @@ class SetupCommandScopeTests(unittest.TestCase):
         ):
             self.assertTrue(setup._is_gnome_or_mutter_session())
 
-    def test_gpt_live_transcribe_is_visible_in_realtime_setup_catalog(self):
+    def test_openai_transcription_models_use_recommended_setup_order(self):
         class SelectFirstPrompt:
             @staticmethod
             def ask(*_args, **_kwargs):
@@ -90,9 +90,14 @@ class SetupCommandScopeTests(unittest.TestCase):
 
         self.assertEqual(
             selection,
-            ("openai", "gpt-live-transcribe", "sk-existing-key", None),
+            ("openai", "gpt-transcribe", "sk-existing-key", None),
         )
-        self.assertIn("OpenAI: GPT Live Transcribe", output.getvalue())
+        catalog = output.getvalue()
+        transcribe_position = catalog.index("OpenAI: GPT Transcribe")
+        live_position = catalog.index("OpenAI: GPT Live Transcribe")
+        whisper_position = catalog.index("OpenAI: GPT Realtime Whisper")
+        self.assertLess(transcribe_position, live_position)
+        self.assertLess(live_position, whisper_position)
 
 
 class ConfigDefaultTests(unittest.TestCase):

--- a/tests/test_setup_command_scope.py
+++ b/tests/test_setup_command_scope.py
@@ -45,6 +45,15 @@ from cli import config, install, setup, systemd, uninstall  # noqa: E402
 from config_manager import ConfigManager  # noqa: E402
 
 
+def _unredirected_path_globals(module, redirected):
+    """Module-level filesystem paths a sandboxed run would still act on."""
+    return sorted(
+        name
+        for name, value in vars(module).items()
+        if name.isupper() and isinstance(value, Path) and name not in redirected
+    )
+
+
 class SetupCommandScopeTests(unittest.TestCase):
     def test_run_command_is_not_function_local(self):
         # Regression: a conditional local re-import of run_command made it a
@@ -184,23 +193,38 @@ class UninstallYdotoolOwnershipTests(unittest.TestCase):
             calls.append(cmd)
             return types.SimpleNamespace(returncode=0, stdout="", stderr="")
 
+        redirected_paths = {
+            "USER_SYSTEMD_DIR": user_systemd,
+            "USER_HOME": root / "missing-home",
+            "USER_CONFIG_DIR": root / "missing-config",
+            "VENV_DIR": root / "missing-venv",
+            "PYWHISPERCPP_SRC_DIR": root / "missing-src",
+            "PYWHISPERCPP_MODELS_DIR": root / "missing-models",
+            "STATE_DIR": root / "missing-state",
+            "CREDENTIALS_FILE": root / "missing-creds",
+            "USER_BASE": root / "missing-user-base",
+        }
+        self.assertEqual(
+            _unredirected_path_globals(uninstall, redirected_paths),
+            [],
+            "uninstall gained a filesystem path this test does not redirect; it "
+            "would operate on the real machine",
+        )
+
         patches = [
-            mock.patch.object(uninstall, "USER_SYSTEMD_DIR", user_systemd),
-            mock.patch.object(uninstall, "USER_HOME", root / "missing-home"),
-            mock.patch.object(uninstall, "USER_CONFIG_DIR", root / "missing-config"),
-            mock.patch.object(uninstall, "VENV_DIR", root / "missing-venv"),
-            mock.patch.object(uninstall, "PYWHISPERCPP_SRC_DIR", root / "missing-src"),
-            mock.patch.object(uninstall, "PYWHISPERCPP_MODELS_DIR", root / "missing-models"),
-            mock.patch.object(uninstall, "STATE_DIR", root / "missing-state"),
-            mock.patch.object(uninstall, "CREDENTIALS_FILE", root / "missing-creds"),
-            mock.patch.object(uninstall, "USER_BASE", root / "missing-user-base"),
+            mock.patch.object(uninstall, name, value)
+            for name, value in redirected_paths.items()
+        ]
+        patches += [
             mock.patch.object(uninstall, "setup_waybar"),
             mock.patch.object(uninstall, "_detect_current_backend", return_value=None),
             mock.patch.object(uninstall, "run_command", side_effect=fake_run_command),
+            mock.patch.object(systemd, "run_command", side_effect=fake_run_command),
         ]
         with contextlib.ExitStack() as stack:
             for patch in patches:
                 stack.enter_context(patch)
+            stack.enter_context(contextlib.redirect_stdout(io.StringIO()))
             uninstall.uninstall_command(skip_permissions=True, yes=True)
 
         return ydotool_unit, calls


### PR DESCRIPTION
# Add GPT Transcribe support

Follow-up to #226.

## Summary

- add `gpt-transcribe` to the OpenAI realtime setup catalog as the recommended general-purpose option
- configure committed-turn transcription with language hints, prompt context, manual commits, and 24 kHz PCM audio
- centralize OpenAI transcription-model capabilities so payloads, mode guards, and preview behavior stay aligned
- keep GPT Live Transcribe as the higher-cost continuous-preview option and GPT Realtime Whisper for legacy
  compatibility
- update configuration documentation, schema descriptions, and regression coverage

## Model-specific behavior

GPT Transcribe uses the existing scalar `language` setting as a single-entry `languages` hint and does not send the
legacy singular `language` field.

Its prompt uses the existing active-language fallback:

```text
whisper_prompt_<active language> → whisper_prompt → omitted
```

Language and prompt updates are sent together so language changes cannot use mismatched context.

Sessions use manual turn detection and explicitly commit the audio buffer when recording stops. GPT Transcribe omits the
live-only `delay` field and does not enable waveform partial previews because transcription begins after the committed
turn.

All dedicated OpenAI transcription models are restricted to `realtime_mode: "transcribe"`.

## Model positioning

- **GPT Transcribe** — recommended for most users; accurate, fast, inexpensive committed-turn transcription
- **GPT Live Transcribe** — continuous live deltas and the best OSD previews; higher cost
- **GPT Realtime Whisper** — legacy compatibility

No new configuration keys or migration are introduced. Profiles, keywords, and a dedicated GPT Transcribe prompt setting
remain outside this change.

References:

- [Realtime committed-turn transcription](https://developers.openai.com/api/docs/guides/realtime-transcription#transcribe-a-committed-turn)
- [Migrating from Whisper to GPT Transcribe](https://developers.openai.com/cookbook/examples/migrating_from_whisper_to_gpt_transcribe)

## Validation

- [x] exact GPT Transcribe session payload
- [x] singular-to-array language conversion
- [x] language-specific prompt, global fallback, and prompt omission
- [x] manual turn detection and explicit audio commit
- [x] detected-language completion metadata
- [x] transcription-only mode guard
- [x] recommended setup ordering
- [x] waveform partial-preview exclusion
- [x] configuration schema/default synchronization
- [x] live microphone/OpenAI end-to-end test

Focused validation:

```text
python -m unittest -v tests.test_realtime_client tests.test_elevenlabs_pill_preview tests.test_setup_command_scope tests.test_config_schema_sync
```

Result: 57 tests passed.

Full validation:

```text
python -m unittest discover -s tests -v
```

Result: 396 of 398 tests passed. The two untouched `SuspendMonitorLifecycleTests` error in this environment because the
optional D-Bus/GLib bindings are unavailable, leaving `suspend_monitor.DBusGMainLoop` undefined for their patch target.
