### PR TITLE
installer: search for any usable g++ as CUDA host compiler

### DIFF
--- a/lib/src/backend_installer.py
+++ b/lib/src/backend_installer.py
@@ -764,10 +764,13 @@ def detect_cuda_host_compiler() -> Optional[str]:
             gcc_version = _safe_decode(result.stdout).strip()
             gcc_major = int(gcc_version.split('.')[0])
             
-            # If GCC >= 15, prefer gcc14 if present
+            # If GCC is newer than the CUDA toolkit accepts, fall back to the
+            # newest older g++ that is actually installed.
             if gcc_major >= 15:
-                if shutil.which('g++-14'):
-                    return '/usr/bin/g++-14'
+                for major in range(gcc_major - 1, 12, -1):
+                    candidate = shutil.which(f'g++-{major}')
+                    if candidate:
+                        return candidate
     except Exception:
         pass
     


### PR DESCRIPTION
CUDA rejects host compilers newer than it supports (CUDA 13.3 hard-errors above GCC 15), so `detect_cuda_host_compiler()` falls back to an older `g++`. But it only checks for `g++-14`:

```python
if gcc_major >= 15:
    if shutil.which('g++-14'):
        return '/usr/bin/g++-14'
```

On Arch with GCC 16 and `g++-15` installed, `g++-14` isn't found, so it falls through and returns the system `g++` — GCC 16, the one CUDA refuses. Setup then fails building pywhispercpp with `unsupported GNU version`.

This counts down from the system version and returns the first `g++-N` actually installed, so GCC 16 finds `g++-15` and future releases keep working without another edit. Also returns the path `shutil.which` found instead of assuming `/usr/bin/`.

Tested on Arch (GCC 16.1.1, CUDA 13.3, `g++-15` present): now returns `/usr/bin/g++-15` and the CUDA build completes. `HYPRWHSPR_CUDA_HOST` still takes precedence.

One caveat, in case it's worth building on later: this is still a heuristic. It assumes a version below the system compiler will be acceptable to CUDA, rather than checking what the installed toolkit actually supports — so if a distro ever jumped far enough ahead, it would try one or more still-unsupported versions before landing on a working one. The precise approach would be to read the `__GNUC__ > N` limit from the toolkit's `crt/host_config.h` and pick the newest `g++` at or below it. I've kept this change minimal rather than doing that here.
