### PR TITLE
fix: don't treat a failed package install as missing Vulkan

### DIFF
--- a/lib/src/backend_installer.py
+++ b/lib/src/backend_installer.py
@@ -1157,11 +1157,15 @@ def setup_vulkan_support() -> bool:
                 check=False
             )
             if not result or result.returncode != 0:
-                log_warning("Failed to install some Vulkan packages")
-                return False
+                # Not fatal. These packages are frequently already installed, and
+                # the call can fail for reasons unrelated to Vulkan support: no
+                # cached sudo credential in a non-interactive setup, a locked
+                # pacman database, a mirror timeout. Step 2 below is the
+                # authoritative capability check, so fall through and let it
+                # decide rather than silently downgrading a working GPU to CPU.
+                log_warning("Could not install Vulkan packages, checking for an existing Vulkan setup")
         except Exception as e:
-            log_error(f"Failed to install Vulkan dependencies: {e}")
-            return False
+            log_warning(f"Could not install Vulkan dependencies ({e}), checking for an existing Vulkan setup")
     else:
         # Check if Vulkan development files are available
         log_info("Checking for Vulkan development files...")

--- a/lib/src/backend_installer.py
+++ b/lib/src/backend_installer.py
@@ -1157,12 +1157,6 @@ def setup_vulkan_support() -> bool:
                 check=False
             )
             if not result or result.returncode != 0:
-                # Not fatal. These packages are frequently already installed, and
-                # the call can fail for reasons unrelated to Vulkan support: no
-                # cached sudo credential in a non-interactive setup, a locked
-                # pacman database, a mirror timeout. Step 2 below is the
-                # authoritative capability check, so fall through and let it
-                # decide rather than silently downgrading a working GPU to CPU.
                 log_warning("Could not install Vulkan packages, checking for an existing Vulkan setup")
         except Exception as e:
             log_warning(f"Could not install Vulkan dependencies ({e}), checking for an existing Vulkan setup")

--- a/tests/test_vulkan_setup.py
+++ b/tests/test_vulkan_setup.py
@@ -1,0 +1,60 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "lib" / "src"))
+
+import backend_installer  # noqa: E402
+
+
+class FakeResult:
+    def __init__(self, returncode=0, stdout=b""):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+GPU_SUMMARY = b"GPU0:\n\tapiVersion = 1.4.354\n\tdeviceName = Radeon RX 9070 XT\n\tdeviceType = PHYSICAL_DEVICE_TYPE_DISCRETE_GPU\n"
+
+
+class SetupVulkanSupportTests(unittest.TestCase):
+    """The package install is a convenience; `vulkaninfo` is the real check.
+
+    A failed `pacman` call must not be treated as "this machine has no Vulkan",
+    because the packages are commonly already installed and the call can fail
+    for unrelated reasons (no cached sudo credential, locked database, mirror
+    timeout). Bailing early silently downgrades a working GPU to CPU.
+    """
+
+    def _run(self, pacman_result=None, pacman_exc=None, has_gpu=True):
+        def fake_which(name):
+            return f"/usr/bin/{name}" if name in ("pacman", "vulkaninfo") else None
+
+        sudo = mock.Mock(side_effect=pacman_exc) if pacman_exc else mock.Mock(return_value=pacman_result)
+
+        with mock.patch.object(backend_installer.shutil, "which", side_effect=fake_which), \
+             mock.patch.object(backend_installer, "run_sudo_command", sudo), \
+             mock.patch.object(backend_installer, "run_command", return_value=FakeResult(0, GPU_SUMMARY)), \
+             mock.patch.object(backend_installer, "vulkaninfo_has_hardware_gpu", return_value=has_gpu):
+            return backend_installer.setup_vulkan_support()
+
+    def test_failed_package_install_still_detects_working_vulkan(self):
+        self.assertTrue(self._run(pacman_result=FakeResult(returncode=1)))
+
+    def test_sudo_exception_still_detects_working_vulkan(self):
+        self.assertTrue(self._run(pacman_exc=PermissionError("a password is required")))
+
+    def test_no_result_from_package_install_still_detects_working_vulkan(self):
+        self.assertTrue(self._run(pacman_result=None))
+
+    def test_successful_package_install_detects_working_vulkan(self):
+        self.assertTrue(self._run(pacman_result=FakeResult(returncode=0)))
+
+    def test_still_returns_false_when_no_hardware_gpu(self):
+        """The capability check must remain authoritative in both directions."""
+        self.assertFalse(self._run(pacman_result=FakeResult(returncode=1), has_gpu=False))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vulkan_setup.py
+++ b/tests/test_vulkan_setup.py
@@ -19,13 +19,7 @@ GPU_SUMMARY = b"GPU0:\n\tapiVersion = 1.4.354\n\tdeviceName = Radeon RX 9070 XT\
 
 
 class SetupVulkanSupportTests(unittest.TestCase):
-    """The package install is a convenience; `vulkaninfo` is the real check.
-
-    A failed `pacman` call must not be treated as "this machine has no Vulkan",
-    because the packages are commonly already installed and the call can fail
-    for unrelated reasons (no cached sudo credential, locked database, mirror
-    timeout). Bailing early silently downgrades a working GPU to CPU.
-    """
+    """The package install is a convenience; `vulkaninfo` is the real check."""
 
     def _run(self, pacman_result=None, pacman_exc=None, has_gpu=True):
         def fake_which(name):


### PR DESCRIPTION
## Problem

`setup_vulkan_support()` returns `False` as soon as the `pacman` call fails, which short-circuits the `vulkaninfo` capability check directly below it. Callers read that `False` as "this machine has no usable Vulkan" and fall back to CPU, so a machine with a working GPU silently ends up with a CPU-only `pywhispercpp` build.

The failure is silent. There is no error, just transcription that is an order of magnitude slower than it should be.

## How I hit it

Arch, RX 9070 XT, running `hyprwhspr setup auto --backend vulkan` non-interactively. All four packages were already installed, so the `pacman -S --needed` call would have been a no-op, but it could not prompt for a sudo password:

```
[INFO] Installing Vulkan dependencies...
[WARNING] Failed to install some Vulkan packages
[WARNING] Vulkan backend selected but Vulkan not available, falling back to CPU
[INFO] Installing pywhispercpp (CPU-only)...
```

`vulkaninfo --summary` reported the GPU correctly the whole time. Building `pywhispercpp` by hand with `GGML_VULKAN=1` works fine on the same machine:

```
ggml_vulkan: 0 = AMD Radeon RX 9070 XT (RADV GFX1201) | fp16: 1 | bf16: 1 | matrix cores: KHR_coopmat
whisper_backend_init_gpu: using Vulkan0 backend
```

Sudo credentials are also cached per TTY by default, so `sudo -v` in another terminal does not help a setup run started elsewhere.

## Why it is worth fixing

The package install is a convenience, not the capability check. Those packages are frequently already present, and the call can fail for reasons unrelated to Vulkan support: no cached sudo credential during a non-interactive `setup auto`, a locked pacman database, a mirror timeout.

Arch users currently get a *weaker* check than everyone else. The non-pacman branch already falls through to the `vulkaninfo` verification at step 2, and only the pacman branch bails early.

## Change

Make the failed install a warning and fall through, letting the existing capability check decide. That check is already authoritative in both directions: it returns `False` when `vulkaninfo` is missing, when it exits non-zero, or when only a software renderer is present.

No behavior change when the install succeeds, and no change on non-pacman systems.

## Tests

Added `tests/test_vulkan_setup.py`, 5 cases covering a failed install, a raised exception, a `None` result, a successful install, and the software-renderer case that must still return `False`. Verified they fail without the change (3 of 5) and pass with it.

Full suite: 382 tests, same 15 pre-existing errors as `main` at `ceef641` (a `src.paths` import in `mic_osd`, unrelated to this change). Baseline is 377 tests with the same 15.