### PR TITLE
fix(mic-osd): keep the overlay from staying on screen after a stalled recording cleanup

### DIFF
--- a/lib/main.py
+++ b/lib/main.py
@@ -1315,21 +1315,17 @@ class hyprwhsprApp:
 
     def _cleanup_recording_state(self):
         """Best-effort cleanup after any recording ends. Safe to call multiple times."""
-        # Publish the end of the recording before anything that can block. The
-        # overlay's auto-hide and `record toggle` both read recording_status, and
-        # teardown can stall on a capture that stopped responding - a status left
-        # at 'true' for that long keeps the visualizer on screen and inverts the
-        # next toggle (#249).
+        # Release recording state and capture clients before teardown can block.
         try:
             self._write_recording_status(False)
         except Exception:
             pass
+        self._notify_capture("", final=True)
         try:
             self._hide_mic_osd()
         except Exception:
             pass
 
-        self._notify_capture("", final=True)
         self._autostop_stop_silence_monitor()
 
         try:

--- a/lib/main.py
+++ b/lib/main.py
@@ -1321,12 +1321,14 @@ class hyprwhsprApp:
         except Exception:
             pass
         self._notify_capture("", final=True)
+
+        # Retire this recording's monitor before hide can block long enough for
+        # a later recording to install its own monitor in the shared slot.
+        self._autostop_stop_silence_monitor()
         try:
             self._hide_mic_osd()
         except Exception:
             pass
-
-        self._autostop_stop_silence_monitor()
 
         try:
             self._clear_mic_osd_preview_text()

--- a/lib/main.py
+++ b/lib/main.py
@@ -1308,6 +1308,20 @@ class hyprwhsprApp:
 
     def _cleanup_recording_state(self):
         """Best-effort cleanup after any recording ends. Safe to call multiple times."""
+        # Publish the end of the recording before anything that can block. The
+        # overlay's auto-hide and `record toggle` both read recording_status, and
+        # teardown can stall on a capture that stopped responding - a status left
+        # at 'true' for that long keeps the visualizer on screen and inverts the
+        # next toggle (#249).
+        try:
+            self._write_recording_status(False)
+        except Exception:
+            pass
+        try:
+            self._hide_mic_osd()
+        except Exception:
+            pass
+
         self._notify_capture("", final=True)
         self._autostop_stop_silence_monitor()
 
@@ -1316,15 +1330,7 @@ class hyprwhsprApp:
         except Exception:
             pass
         try:
-            self._hide_mic_osd()
-        except Exception:
-            pass
-        try:
             self._stop_audio_level_monitoring()
-        except Exception:
-            pass
-        try:
-            self._write_recording_status(False)
         except Exception:
             pass
         try:

--- a/lib/mic_osd/main.py
+++ b/lib/mic_osd/main.py
@@ -66,15 +66,10 @@ class MicOSD:
     Mic-osd application with show/hide support.
     """
     
-    # A recording_status of 'true' is only believed while the controller keeps
-    # advancing its level feed; this is how long the feed may stall first.
-    FEED_GRACE_SECONDS = 3.0
-
     def __init__(self, visualization="waveform", width=400, height=68, daemon=False):
         self.main_loop = None
         self.app = None
         self.audio_monitor = None
-        self._feed_liveness = False
         self.window = None
         self.update_timer_id = None
         self._auto_hide_timeout_id = None
@@ -212,11 +207,7 @@ class MicOSD:
         # Prefer the main process's level feed (tracks the recorded device, no
         # contention); fall back to opening the default input directly.
         if not self.audio_monitor:
-            self._feed_liveness = bool(
-                FeedLevelSource is not None
-                and FeedLevelSource.available(MIC_OSD_LEVEL_FEED_FILE)
-            )
-            if self._feed_liveness:
+            if FeedLevelSource is not None and FeedLevelSource.available(MIC_OSD_LEVEL_FEED_FILE):
                 self.audio_monitor = FeedLevelSource(MIC_OSD_LEVEL_FEED_FILE)
             else:
                 self.audio_monitor = AudioMonitor(samplerate=44100, blocksize=1024)
@@ -392,21 +383,6 @@ class MicOSD:
             # File read error - assume not recording, allow hide
             pass
         
-        if recording_active and self._feed_liveness and not FeedLevelSource.available(
-            MIC_OSD_LEVEL_FEED_FILE, max_age=self.FEED_GRACE_SECONDS
-        ):
-            # The controller streams a feed frame every tick while capturing but
-            # only writes recording_status when a recording starts or ends, so a
-            # controller that stalls in teardown (typically on a wedged capture
-            # stream) leaves it set to 'true' indefinitely. Trusting the status
-            # file alone therefore pins this window on screen long after capture
-            # died. A feed that stopped advancing proves capture is gone (#249).
-            print("[MIC-OSD] Level feed went stale while recording_status says "
-                  "recording - hiding (controller stalled)", flush=True)
-            self._hide()
-            self._auto_hide_timeout_id = None
-            return False  # Don't repeat
-
         if recording_active:
             # Recording is still active - reset timeout instead of hiding
             print("[MIC-OSD] Recording active - resetting auto-hide timeout", flush=True)

--- a/lib/mic_osd/main.py
+++ b/lib/mic_osd/main.py
@@ -66,10 +66,15 @@ class MicOSD:
     Mic-osd application with show/hide support.
     """
     
+    # A recording_status of 'true' is only believed while the controller keeps
+    # advancing its level feed; this is how long the feed may stall first.
+    FEED_GRACE_SECONDS = 3.0
+
     def __init__(self, visualization="waveform", width=400, height=68, daemon=False):
         self.main_loop = None
         self.app = None
         self.audio_monitor = None
+        self._feed_liveness = False
         self.window = None
         self.update_timer_id = None
         self._auto_hide_timeout_id = None
@@ -207,7 +212,11 @@ class MicOSD:
         # Prefer the main process's level feed (tracks the recorded device, no
         # contention); fall back to opening the default input directly.
         if not self.audio_monitor:
-            if FeedLevelSource is not None and FeedLevelSource.available(MIC_OSD_LEVEL_FEED_FILE):
+            self._feed_liveness = bool(
+                FeedLevelSource is not None
+                and FeedLevelSource.available(MIC_OSD_LEVEL_FEED_FILE)
+            )
+            if self._feed_liveness:
                 self.audio_monitor = FeedLevelSource(MIC_OSD_LEVEL_FEED_FILE)
             else:
                 self.audio_monitor = AudioMonitor(samplerate=44100, blocksize=1024)
@@ -383,6 +392,21 @@ class MicOSD:
             # File read error - assume not recording, allow hide
             pass
         
+        if recording_active and self._feed_liveness and not FeedLevelSource.available(
+            MIC_OSD_LEVEL_FEED_FILE, max_age=self.FEED_GRACE_SECONDS
+        ):
+            # The controller streams a feed frame every tick while capturing but
+            # only writes recording_status when a recording starts or ends, so a
+            # controller that stalls in teardown (typically on a wedged capture
+            # stream) leaves it set to 'true' indefinitely. Trusting the status
+            # file alone therefore pins this window on screen long after capture
+            # died. A feed that stopped advancing proves capture is gone (#249).
+            print("[MIC-OSD] Level feed went stale while recording_status says "
+                  "recording - hiding (controller stalled)", flush=True)
+            self._hide()
+            self._auto_hide_timeout_id = None
+            return False  # Don't repeat
+
         if recording_active:
             # Recording is still active - reset timeout instead of hiding
             print("[MIC-OSD] Recording active - resetting auto-hide timeout", flush=True)

--- a/lib/mic_osd/runner.py
+++ b/lib/mic_osd/runner.py
@@ -68,8 +68,10 @@ class MicOSDRunner:
         self._level_source = level_source
         self._level_feed_thread = None
         self._level_feed_stop = threading.Event()
-        self._level_feed_lock = threading.Lock()
+        self._level_feed_lock = threading.RLock()
         self._last_level_feed_error_at = 0.0
+        self._visibility_lock = threading.Lock()
+        self._hide_generation = 0
     
     @staticmethod
     def is_available() -> bool:
@@ -440,16 +442,27 @@ sys.exit(main())
 
     def show(self) -> bool:
         """Show the mic-osd overlay (instant via signal)."""
+        with self._visibility_lock:
+            generation = self._hide_generation
+
         if not self.is_available():
             return False
 
         if not self._ensure_daemon():
             return False
 
-        self._start_level_feed()  # before signaling; first frame must be ready
-
         try:
-            return self._signal_daemon(signal.SIGUSR1)
+            with self._level_feed_lock:
+                with self._visibility_lock:
+                    if generation != self._hide_generation:
+                        return False
+                self._start_level_feed()  # first frame must be ready before SIGUSR1
+                with self._visibility_lock:
+                    # A hide during the first frame cancels this show. Keep
+                    # teardown serialized until we have decided whether to signal.
+                    if generation != self._hide_generation:
+                        return False
+                    return self._signal_daemon(signal.SIGUSR1)
         except (ProcessLookupError, OSError):
             self._stop_level_feed()
             self._process = None
@@ -458,12 +471,12 @@ sys.exit(main())
 
     def hide(self):
         """Hide the mic-osd overlay (instant via signal)."""
-        # Signal before the teardown below: _stop_level_feed() waits on
-        # _level_feed_lock, which _start_level_feed() holds across a first-frame
-        # write that blocks while the capture is unresponsive. Bookkeeping that
-        # stalls must not decide whether the overlay leaves the screen (#249).
+        # Do not wait for a blocked level source to hide the window. The
+        # generation check prevents an in-flight show from undoing this signal.
         try:
-            self._signal_hide()
+            with self._visibility_lock:
+                self._hide_generation += 1
+                self._signal_hide()
         finally:
             self._stop_level_feed()
             self.clear_preview_text()
@@ -487,7 +500,6 @@ sys.exit(main())
                 self._orphaned_daemon_pid = None
                 # Clean up stale PID file
                 self._unlink_pid_file()
-                self.clear_preview_text()
                 return
         
         # For normal daemons, verify process is actually alive before signaling
@@ -498,7 +510,6 @@ sys.exit(main())
             self._orphaned_daemon_pid = None
             # Clean up stale PID file
             self._unlink_pid_file()
-            self.clear_preview_text()
             return
         
         # Verify process is actually alive before sending signal
@@ -511,7 +522,6 @@ sys.exit(main())
             self._orphaned_daemon_pid = None
             # Clean up stale PID file
             self._unlink_pid_file()
-            self.clear_preview_text()
             return
         
         # Process is alive, send hide signal
@@ -521,7 +531,6 @@ sys.exit(main())
             print(f"[MIC-OSD] Failed to send SIGUSR2 to daemon (PID {self._process.pid}): {e}", flush=True)
             self._process = None
             self._orphaned_daemon_pid = None
-            self.clear_preview_text()
 
     def set_state(self, state: str):
         """

--- a/lib/mic_osd/runner.py
+++ b/lib/mic_osd/runner.py
@@ -458,9 +458,18 @@ sys.exit(main())
 
     def hide(self):
         """Hide the mic-osd overlay (instant via signal)."""
-        self._stop_level_feed()
-        self.clear_preview_text()
+        # Signal before the teardown below: _stop_level_feed() waits on
+        # _level_feed_lock, which _start_level_feed() holds across a first-frame
+        # write that blocks while the capture is unresponsive. Bookkeeping that
+        # stalls must not decide whether the overlay leaves the screen (#249).
+        try:
+            self._signal_hide()
+        finally:
+            self._stop_level_feed()
+            self.clear_preview_text()
 
+    def _signal_hide(self):
+        """Send SIGUSR2 to the daemon, dropping references to a dead one."""
         if self._process is None:
             return
         

--- a/lib/mic_osd/runner.py
+++ b/lib/mic_osd/runner.py
@@ -70,8 +70,9 @@ class MicOSDRunner:
         self._level_feed_stop = threading.Event()
         self._level_feed_lock = threading.RLock()
         self._last_level_feed_error_at = 0.0
-        self._visibility_lock = threading.Lock()
+        self._visibility_condition = threading.Condition()
         self._hide_generation = 0
+        self._hide_teardowns = 0
     
     @staticmethod
     def is_available() -> bool:
@@ -442,7 +443,9 @@ sys.exit(main())
 
     def show(self) -> bool:
         """Show the mic-osd overlay (instant via signal)."""
-        with self._visibility_lock:
+        with self._visibility_condition:
+            while self._hide_teardowns:
+                self._visibility_condition.wait()
             generation = self._hide_generation
 
         if not self.is_available():
@@ -453,11 +456,11 @@ sys.exit(main())
 
         try:
             with self._level_feed_lock:
-                with self._visibility_lock:
+                with self._visibility_condition:
                     if generation != self._hide_generation:
                         return False
                 self._start_level_feed()  # first frame must be ready before SIGUSR1
-                with self._visibility_lock:
+                with self._visibility_condition:
                     # A hide during the first frame cancels this show. Keep
                     # teardown serialized until we have decided whether to signal.
                     if generation != self._hide_generation:
@@ -472,14 +475,21 @@ sys.exit(main())
     def hide(self):
         """Hide the mic-osd overlay (instant via signal)."""
         # Do not wait for a blocked level source to hide the window. The
-        # generation check prevents an in-flight show from undoing this signal.
+        # generation check prevents an in-flight show from undoing this signal,
+        # while the teardown counter keeps a newer show from overtaking cleanup.
         try:
-            with self._visibility_lock:
+            with self._visibility_condition:
                 self._hide_generation += 1
+                self._hide_teardowns += 1
                 self._signal_hide()
         finally:
-            self._stop_level_feed()
-            self.clear_preview_text()
+            try:
+                self._stop_level_feed()
+                self.clear_preview_text()
+            finally:
+                with self._visibility_condition:
+                    self._hide_teardowns -= 1
+                    self._visibility_condition.notify_all()
 
     def _signal_hide(self):
         """Send SIGUSR2 to the daemon, dropping references to a dead one."""

--- a/tests/test_mic_osd_runner.py
+++ b/tests/test_mic_osd_runner.py
@@ -1,7 +1,6 @@
 import sys
 import tempfile
 import threading
-import time
 import types
 import unittest
 import builtins
@@ -376,34 +375,91 @@ class MicOSDRunnerTests(unittest.TestCase):
                 runner_module.TRANSCRIPT_PREVIEW_FILE = original_file
                 MicOSDRunner.PREVIEW_WRITE_INTERVAL_SECONDS = original_interval
 
-    def test_hide_signals_the_daemon_while_feed_teardown_is_stalled(self):
-        # _stop_level_feed() waits on _level_feed_lock, which a first-frame write
-        # can hold while the capture is unresponsive. The overlay must leave the
-        # screen regardless: the signal goes out before that bookkeeping.
-        runner = MicOSDRunner()
-        runner._process = types.SimpleNamespace(pid=4242, poll=lambda: None)
+    def test_hide_cancels_show_blocked_on_first_feed_frame(self):
+        source_entered = threading.Event()
+        source_release = threading.Event()
+        hidden = threading.Event()
         signals = []
-        teardown_release = threading.Event()
-        teardown_finished = threading.Event()
+        show_results = []
 
-        def stalled_teardown():
-            teardown_release.wait(5)
-            teardown_finished.set()
+        def blocked_source():
+            source_entered.set()
+            if not source_release.wait(5):
+                raise TimeoutError("test did not release level source")
+            return 0.0, []
 
-        with mock.patch.object(runner, "_stop_level_feed", side_effect=stalled_teardown), \
-                mock.patch.object(runner_module.os, "kill",
-                                  side_effect=lambda pid, sig: signals.append(sig)):
-            worker = threading.Thread(target=runner.hide, daemon=True)
+        def record_signal(pid, sig):
+            if sig in (signal.SIGUSR1, signal.SIGUSR2):
+                signals.append(sig)
+            if sig == signal.SIGUSR2:
+                hidden.set()
+
+        runner = MicOSDRunner(level_source=blocked_source)
+        runner._process = types.SimpleNamespace(pid=4242, poll=lambda: None)
+        with tempfile.TemporaryDirectory() as tmp, \
+                mock.patch.object(runner_module, "MIC_OSD_LEVEL_FEED_FILE", Path(tmp) / "feed"), \
+                mock.patch.object(runner_module, "TRANSCRIPT_PREVIEW_FILE", Path(tmp) / "preview"), \
+                mock.patch.object(runner, "is_available", return_value=True), \
+                mock.patch.object(runner, "_ensure_daemon", return_value=True), \
+                mock.patch.object(runner_module.os, "kill", side_effect=record_signal):
+            showing = threading.Thread(target=lambda: show_results.append(runner.show()))
+            hiding = threading.Thread(target=runner.hide)
+            showing.start()
+            try:
+                self.assertTrue(source_entered.wait(2), "show did not reach level source")
+                hiding.start()
+                self.assertTrue(hidden.wait(2), "hide waited for the blocked level source")
+                self.assertTrue(hiding.is_alive(), "feed teardown should still be blocked")
+            finally:
+                source_release.set()
+                showing.join(5)
+                if hiding.ident is not None:
+                    hiding.join(5)
+                runner._stop_level_feed()
+            self.assertFalse(showing.is_alive())
+            self.assertFalse(hiding.is_alive())
+            self.assertEqual(signals, [signal.SIGUSR2])
+            self.assertEqual(show_results, [False])
+
+            # Cancellation must not prevent the next recording from showing.
+            self.assertTrue(runner.show())
+            runner.hide()
+            self.assertEqual(signals[-2:], [signal.SIGUSR1, signal.SIGUSR2])
+
+    def test_hide_during_daemon_startup_does_not_start_a_feed(self):
+        runner = MicOSDRunner(level_source=lambda: (0.0, []))
+        startup_entered = threading.Event()
+        startup_release = threading.Event()
+        results = []
+        signals = []
+
+        def start_daemon():
+            startup_entered.set()
+            startup_release.wait(5)
+            runner._process = types.SimpleNamespace(pid=4242, poll=lambda: None)
+            return True
+
+        with tempfile.TemporaryDirectory() as tmp, \
+                mock.patch.object(runner_module, "MIC_OSD_LEVEL_FEED_FILE", Path(tmp) / "feed"), \
+                mock.patch.object(runner_module, "TRANSCRIPT_PREVIEW_FILE", Path(tmp) / "preview"), \
+                mock.patch.object(runner, "is_available", return_value=True), \
+                mock.patch.object(runner, "_ensure_daemon", side_effect=start_daemon), \
+                mock.patch.object(runner_module.os, "kill", side_effect=lambda pid, sig: signals.append(sig)):
+            worker = threading.Thread(target=lambda: results.append(runner.show()))
             worker.start()
             try:
-                deadline = time.monotonic() + 2.0
-                while time.monotonic() < deadline and signal.SIGUSR2 not in signals:
-                    time.sleep(0.01)
-                self.assertIn(signal.SIGUSR2, signals)
-                self.assertFalse(teardown_finished.is_set())
+                self.assertTrue(startup_entered.wait(2))
+                runner.hide()
+                startup_release.set()
+                worker.join(5)
+                self.assertFalse(worker.is_alive())
+                self.assertEqual(results, [False])
+                self.assertNotIn(signal.SIGUSR1, signals)
+                self.assertFalse((Path(tmp) / "feed").exists())
             finally:
-                teardown_release.set()
-            worker.join(timeout=5)
+                startup_release.set()
+                worker.join(5)
+                runner._stop_level_feed()
 
     def test_high_frequency_preview_updates_are_coalesced(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_mic_osd_runner.py
+++ b/tests/test_mic_osd_runner.py
@@ -1,8 +1,11 @@
 import sys
 import tempfile
+import threading
+import time
 import types
 import unittest
 import builtins
+import signal
 from pathlib import Path
 from unittest import mock
 
@@ -372,6 +375,35 @@ class MicOSDRunnerTests(unittest.TestCase):
             finally:
                 runner_module.TRANSCRIPT_PREVIEW_FILE = original_file
                 MicOSDRunner.PREVIEW_WRITE_INTERVAL_SECONDS = original_interval
+
+    def test_hide_signals_the_daemon_while_feed_teardown_is_stalled(self):
+        # _stop_level_feed() waits on _level_feed_lock, which a first-frame write
+        # can hold while the capture is unresponsive. The overlay must leave the
+        # screen regardless: the signal goes out before that bookkeeping.
+        runner = MicOSDRunner()
+        runner._process = types.SimpleNamespace(pid=4242, poll=lambda: None)
+        signals = []
+        teardown_release = threading.Event()
+        teardown_finished = threading.Event()
+
+        def stalled_teardown():
+            teardown_release.wait(5)
+            teardown_finished.set()
+
+        with mock.patch.object(runner, "_stop_level_feed", side_effect=stalled_teardown), \
+                mock.patch.object(runner_module.os, "kill",
+                                  side_effect=lambda pid, sig: signals.append(sig)):
+            worker = threading.Thread(target=runner.hide, daemon=True)
+            worker.start()
+            try:
+                deadline = time.monotonic() + 2.0
+                while time.monotonic() < deadline and signal.SIGUSR2 not in signals:
+                    time.sleep(0.01)
+                self.assertIn(signal.SIGUSR2, signals)
+                self.assertFalse(teardown_finished.is_set())
+            finally:
+                teardown_release.set()
+            worker.join(timeout=5)
 
     def test_high_frequency_preview_updates_are_coalesced(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_mic_osd_runner.py
+++ b/tests/test_mic_osd_runner.py
@@ -461,6 +461,52 @@ class MicOSDRunnerTests(unittest.TestCase):
                 worker.join(5)
                 runner._stop_level_feed()
 
+    def test_new_show_waits_for_previous_hide_teardown(self):
+        runner = MicOSDRunner(level_source=lambda: (0.0, []))
+        runner._process = types.SimpleNamespace(pid=4242, poll=lambda: None)
+        teardown_entered = threading.Event()
+        teardown_release = threading.Event()
+        show_finished = threading.Event()
+        signals = []
+
+        def blocked_teardown():
+            teardown_entered.set()
+            teardown_release.wait(5)
+
+        def show_again():
+            runner.show()
+            show_finished.set()
+
+        def record_signal(pid, sig):
+            if sig in (signal.SIGUSR1, signal.SIGUSR2):
+                signals.append(sig)
+
+        with mock.patch.object(runner, "_stop_level_feed", side_effect=blocked_teardown), \
+                mock.patch.object(runner, "clear_preview_text"), \
+                mock.patch.object(runner, "is_available", return_value=True), \
+                mock.patch.object(runner, "_ensure_daemon", return_value=True), \
+                mock.patch.object(runner_module.os, "kill", side_effect=record_signal):
+            hiding = threading.Thread(target=runner.hide)
+            showing = threading.Thread(target=show_again)
+            hiding.start()
+            try:
+                self.assertTrue(teardown_entered.wait(2))
+                showing.start()
+                self.assertFalse(
+                    show_finished.wait(0.1),
+                    "new show overtook the previous hide teardown",
+                )
+                self.assertNotIn(signal.SIGUSR1, signals)
+            finally:
+                teardown_release.set()
+                hiding.join(5)
+                if showing.ident is not None:
+                    showing.join(5)
+
+            self.assertFalse(hiding.is_alive())
+            self.assertFalse(showing.is_alive())
+            self.assertEqual(signals, [signal.SIGUSR2, signal.SIGUSR1])
+
     def test_high_frequency_preview_updates_are_coalesced(self):
         with tempfile.TemporaryDirectory() as tmp:
             preview_file = Path(tmp) / "hyprwhspr" / "transcript_preview"

--- a/tests/test_mic_osd_stuck_overlay.py
+++ b/tests/test_mic_osd_stuck_overlay.py
@@ -1,17 +1,15 @@
-"""Regression tests for the overlay outliving the controller's capture (#249).
+"""Recording status, not visualization feed freshness, governs auto-hide.
 
-recording_status is only written when a recording starts or ends, while the
-level feed is rewritten every tick. A controller that stalls in teardown (a
-capture stream that stopped responding is the usual cause) therefore leaves
-recording_status at 'true' indefinitely, and the auto-hide - which only ever
-trusted that file - kept re-arming until the overlay was pinned on screen for
-good. A feed that stopped advancing proves the capture is gone.
+Feed publishing can fail while capture continues. A lost or stale waveform
+must not hide an active recording; clearing recording status must hide it
+on the next auto-hide callback even when the feed remains fresh.
 """
 
+import importlib.util
 import os
 import sys
 import tempfile
-import time
+import types
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -19,88 +17,100 @@ from unittest import mock
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "lib"))
 
-try:
-    from mic_osd import main as mic_osd_main
-except ImportError as exc:  # GTK/layer-shell are optional; CI has neither
-    mic_osd_main = None
-    IMPORT_ERROR = exc
-else:
-    IMPORT_ERROR = mic_osd_main._MIC_OSD_IMPORT_ERROR
 
-
-@unittest.skipIf(mic_osd_main is None or IMPORT_ERROR is not None,
-                 "mic-osd GUI stack unavailable")
 class MicOSDStuckOverlayTests(unittest.TestCase):
     def setUp(self):
         runtime = tempfile.TemporaryDirectory()
         self.addCleanup(runtime.cleanup)
         runtime_dir = Path(runtime.name)
-        self.status = runtime_dir / 'recording_status'
-        self.feed = runtime_dir / 'mic_osd_level_feed'
-        self.preview = runtime_dir / 'transcript_preview'
-        for name, path in (
-            ('RECORDING_STATUS_FILE', self.status),
-            ('MIC_OSD_LEVEL_FEED_FILE', self.feed),
-            ('TRANSCRIPT_PREVIEW_FILE', self.preview),
-        ):
-            patcher = mock.patch.object(mic_osd_main, name, path)
-            patcher.start()
-            self.addCleanup(patcher.stop)
+        self.status = runtime_dir / "recording_status"
+        self.feed = runtime_dir / "mic_osd_level_feed"
+        self.preview = runtime_dir / "transcript_preview"
 
-        # Timer arming is observed rather than scheduled: no main loop runs here.
-        timer = mock.patch.object(mic_osd_main.GLib, 'timeout_add_seconds', return_value=7)
-        self.rearm = timer.start()
-        self.addCleanup(timer.stop)
+        # Load isolated modules with only hardware/GUI dependencies stubbed.
+        # Exercise the real feed reader and OSD lifecycle without GTK or audio.
+        audio_spec = importlib.util.spec_from_file_location(
+            "_stuck_overlay_audio", ROOT / "lib" / "mic_osd" / "audio.py"
+        )
+        audio_module = importlib.util.module_from_spec(audio_spec)
+        with mock.patch.dict(sys.modules, {"sounddevice": mock.Mock()}):
+            audio_spec.loader.exec_module(audio_module)
+        audio_module.AudioMonitor = mock.Mock(
+            side_effect=AssertionError("A fresh controller feed must not open a microphone")
+        )
+        glib = types.SimpleNamespace(
+            timeout_add=mock.Mock(return_value=1),
+            timeout_add_seconds=mock.Mock(return_value=7),
+            source_remove=mock.Mock(),
+        )
+        stubs = {
+            "gi": types.SimpleNamespace(require_version=lambda *args: None),
+            "gi.repository": types.SimpleNamespace(Gtk=types.SimpleNamespace(), GLib=glib),
+            "mic_osd.window": types.SimpleNamespace(OSDWindow=mock.Mock(), load_css=mock.Mock()),
+            "mic_osd.audio": audio_module,
+            "mic_osd.visualizations": types.SimpleNamespace(VISUALIZATIONS={"waveform": object}),
+            "mic_osd.theme": types.SimpleNamespace(ThemeWatcher=mock.Mock()),
+        }
+        main_spec = importlib.util.spec_from_file_location(
+            "mic_osd._stuck_overlay_main", ROOT / "lib" / "mic_osd" / "main.py"
+        )
+        self.main = importlib.util.module_from_spec(main_spec)
+        with mock.patch.dict(sys.modules, stubs):
+            main_spec.loader.exec_module(self.main)
+        self.main.RECORDING_STATUS_FILE = self.status
+        self.main.MIC_OSD_LEVEL_FEED_FILE = self.feed
+        self.main.TRANSCRIPT_PREVIEW_FILE = self.preview
+        self.rearm = glib.timeout_add_seconds
 
-    def _visible_app(self, feed_liveness=True):
-        app = mic_osd_main.MicOSD.__new__(mic_osd_main.MicOSD)
-        app.visible = True
-        app.window = None  # _hide() returns before it touches GTK
-        app.audio_monitor = None
-        app._auto_hide_timeout_id = None
-        app._last_preview_text = None
-        app._feed_liveness = feed_liveness
+        # Fix the reader's clock so feed freshness never depends on test speed.
+        clock = mock.patch.object(audio_module.time, "time", return_value=1000.0)
+        clock.start()
+        self.addCleanup(clock.stop)
+
+    def _show_recording(self):
+        self.status.write_text("true")
+        self.feed.write_text("0.5 0.25 0.5")
+        os.utime(self.feed, (1000.0, 1000.0))
+        app = self.main.MicOSD(daemon=True)
+        app.window = mock.Mock()
+        app._show()
+        app.window.reset_mock()
+        self.rearm.reset_mock()
         return app
 
-    def _write_feed(self, age_seconds=0.0):
-        self.feed.write_text('0.0 0.0 0.0')
-        stamp = time.time() - age_seconds
-        os.utime(self.feed, (stamp, stamp))
-
-    def test_dead_feed_hides_overlay_despite_stale_status(self):
-        self.status.write_text('true')
-        self._write_feed(age_seconds=10.0)
-        app = self._visible_app()
-
+    def _assert_recording_stays_visible(self, app):
         self.assertFalse(app._auto_hide_callback())
-
-        self.assertFalse(app.visible)
-        self.rearm.assert_not_called()
-
-    def test_live_feed_keeps_overlay_while_recording(self):
-        self.status.write_text('true')
-        self._write_feed()
-        app = self._visible_app()
-
-        self.assertFalse(app._auto_hide_callback())
-
         self.assertTrue(app.visible)
+        app.window.set_visible.assert_not_called()
         self.rearm.assert_called_once()
 
-    def test_missing_status_hides_overlay(self):
-        app = self._visible_app()
+    def test_feed_stalling_during_recording_does_not_hide_overlay(self):
+        app = self._show_recording()
+        os.utime(self.feed, (0.0, 0.0))
 
-        self.assertFalse(app._auto_hide_callback())
+        self._assert_recording_stays_visible(app)
 
-        self.assertFalse(app.visible)
+    def test_feed_disappearing_during_recording_does_not_hide_overlay(self):
+        app = self._show_recording()
+        self.feed.unlink()
 
-    def test_stale_status_is_still_believed_without_a_feed(self):
-        # Overlay shown without a feed (controller publishes no frames, so the
-        # daemon opened its own stream): there is no liveness signal to check.
-        self.status.write_text('true')
-        app = self._visible_app(feed_liveness=False)
+        self._assert_recording_stays_visible(app)
 
-        self.assertFalse(app._auto_hide_callback())
+    def test_inactive_recording_hides_overlay_even_with_fresh_feed(self):
+        for status in ("false", None):
+            with self.subTest(status=status):
+                app = self._show_recording()
+                if status is None:
+                    self.status.unlink()
+                else:
+                    self.status.write_text(status)
 
-        self.assertTrue(app.visible)
-        self.rearm.assert_called_once()
+                self.assertFalse(app._auto_hide_callback())
+
+                self.assertFalse(app.visible)
+                app.window.set_visible.assert_called_once_with(False)
+                self.rearm.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mic_osd_stuck_overlay.py
+++ b/tests/test_mic_osd_stuck_overlay.py
@@ -1,0 +1,106 @@
+"""Regression tests for the overlay outliving the controller's capture (#249).
+
+recording_status is only written when a recording starts or ends, while the
+level feed is rewritten every tick. A controller that stalls in teardown (a
+capture stream that stopped responding is the usual cause) therefore leaves
+recording_status at 'true' indefinitely, and the auto-hide - which only ever
+trusted that file - kept re-arming until the overlay was pinned on screen for
+good. A feed that stopped advancing proves the capture is gone.
+"""
+
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "lib"))
+
+try:
+    from mic_osd import main as mic_osd_main
+except ImportError as exc:  # GTK/layer-shell are optional; CI has neither
+    mic_osd_main = None
+    IMPORT_ERROR = exc
+else:
+    IMPORT_ERROR = mic_osd_main._MIC_OSD_IMPORT_ERROR
+
+
+@unittest.skipIf(mic_osd_main is None or IMPORT_ERROR is not None,
+                 "mic-osd GUI stack unavailable")
+class MicOSDStuckOverlayTests(unittest.TestCase):
+    def setUp(self):
+        runtime = tempfile.TemporaryDirectory()
+        self.addCleanup(runtime.cleanup)
+        runtime_dir = Path(runtime.name)
+        self.status = runtime_dir / 'recording_status'
+        self.feed = runtime_dir / 'mic_osd_level_feed'
+        self.preview = runtime_dir / 'transcript_preview'
+        for name, path in (
+            ('RECORDING_STATUS_FILE', self.status),
+            ('MIC_OSD_LEVEL_FEED_FILE', self.feed),
+            ('TRANSCRIPT_PREVIEW_FILE', self.preview),
+        ):
+            patcher = mock.patch.object(mic_osd_main, name, path)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+        # Timer arming is observed rather than scheduled: no main loop runs here.
+        timer = mock.patch.object(mic_osd_main.GLib, 'timeout_add_seconds', return_value=7)
+        self.rearm = timer.start()
+        self.addCleanup(timer.stop)
+
+    def _visible_app(self, feed_liveness=True):
+        app = mic_osd_main.MicOSD.__new__(mic_osd_main.MicOSD)
+        app.visible = True
+        app.window = None  # _hide() returns before it touches GTK
+        app.audio_monitor = None
+        app._auto_hide_timeout_id = None
+        app._last_preview_text = None
+        app._feed_liveness = feed_liveness
+        return app
+
+    def _write_feed(self, age_seconds=0.0):
+        self.feed.write_text('0.0 0.0 0.0')
+        stamp = time.time() - age_seconds
+        os.utime(self.feed, (stamp, stamp))
+
+    def test_dead_feed_hides_overlay_despite_stale_status(self):
+        self.status.write_text('true')
+        self._write_feed(age_seconds=10.0)
+        app = self._visible_app()
+
+        self.assertFalse(app._auto_hide_callback())
+
+        self.assertFalse(app.visible)
+        self.rearm.assert_not_called()
+
+    def test_live_feed_keeps_overlay_while_recording(self):
+        self.status.write_text('true')
+        self._write_feed()
+        app = self._visible_app()
+
+        self.assertFalse(app._auto_hide_callback())
+
+        self.assertTrue(app.visible)
+        self.rearm.assert_called_once()
+
+    def test_missing_status_hides_overlay(self):
+        app = self._visible_app()
+
+        self.assertFalse(app._auto_hide_callback())
+
+        self.assertFalse(app.visible)
+
+    def test_stale_status_is_still_believed_without_a_feed(self):
+        # Overlay shown without a feed (controller publishes no frames, so the
+        # daemon opened its own stream): there is no liveness signal to check.
+        self.status.write_text('true')
+        app = self._visible_app(feed_liveness=False)
+
+        self.assertFalse(app._auto_hide_callback())
+
+        self.assertTrue(app.visible)
+        self.rearm.assert_called_once()

--- a/tests/test_recording_cleanup_state.py
+++ b/tests/test_recording_cleanup_state.py
@@ -1,0 +1,75 @@
+"""Regression tests for end-of-recording state surviving a stalled teardown (#249).
+
+Cleanup used to write recording_status last, after the steps that can block for
+minutes when the capture stream stops responding. Consumers that read the file
+(overlay auto-hide, `record toggle`) then saw a recording that had already been
+abandoned - the visualizer stayed on screen and the next toggle sent 'stop'.
+The end state has to be published before any step that can block.
+"""
+
+import sys
+import tempfile
+import threading
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tests.test_suspend_resume_recovery import _import_main_isolated
+
+
+class RecordingCleanupStateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.main = _import_main_isolated()
+
+    def _app(self, status_path):
+        app = self.main.hyprwhsprApp.__new__(self.main.hyprwhsprApp)
+        app.playback_suppressor = types.SimpleNamespace(is_active=False, restore=mock.Mock())
+        app._recording_lock = threading.Lock()
+        app._recording_finalizing = threading.Event()
+        patcher = mock.patch.object(self.main, 'RECORDING_STATUS_FILE', status_path)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        return app
+
+    def test_end_of_recording_is_published_before_blocking_teardown(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            status = Path(tmp) / 'recording_status'
+            status.write_text('true')
+            app = self._app(status)
+
+            hidden = []
+            observed = {}
+            app._hide_mic_osd = mock.Mock(side_effect=lambda: hidden.append(True))
+            app._notify_capture = mock.Mock(side_effect=lambda *args, **kwargs: observed.update(
+                status_still_set=status.exists(),
+                overlay_already_hidden=bool(hidden),
+            ))
+            app._autostop_stop_silence_monitor = mock.Mock()
+            app._clear_mic_osd_preview_text = mock.Mock()
+            app._stop_audio_level_monitoring = mock.Mock()
+
+            app._cleanup_recording_state()
+
+            # First potentially blocking step already sees the recording ended.
+            self.assertFalse(observed['status_still_set'])
+            self.assertTrue(observed['overlay_already_hidden'])
+            self.assertFalse(status.exists())
+
+    def test_cleanup_still_restores_playback_and_stops_monitoring(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            status = Path(tmp) / 'recording_status'
+            status.write_text('true')
+            app = self._app(status)
+            app.playback_suppressor = types.SimpleNamespace(is_active=True, restore=mock.Mock())
+            app._hide_mic_osd = mock.Mock()
+            app._notify_capture = mock.Mock()
+            app._autostop_stop_silence_monitor = mock.Mock()
+            app._clear_mic_osd_preview_text = mock.Mock()
+            app._stop_audio_level_monitoring = mock.Mock()
+
+            app._cleanup_recording_state()
+
+            app._stop_audio_level_monitoring.assert_called_once()
+            app.playback_suppressor.restore.assert_called_once()

--- a/tests/test_recording_cleanup_state.py
+++ b/tests/test_recording_cleanup_state.py
@@ -1,13 +1,6 @@
-"""Regression tests for end-of-recording state surviving a stalled teardown (#249).
+"""Recording cleanup must release status and capture clients before teardown."""
 
-Cleanup used to write recording_status last, after the steps that can block for
-minutes when the capture stream stops responding. Consumers that read the file
-(overlay auto-hide, `record toggle`) then saw a recording that had already been
-abandoned - the visualizer stayed on screen and the next toggle sent 'stop'.
-The end state has to be published before any step that can block.
-"""
-
-import sys
+import socket
 import tempfile
 import threading
 import types
@@ -25,51 +18,85 @@ class RecordingCleanupStateTests(unittest.TestCase):
 
     def _app(self, status_path):
         app = self.main.hyprwhsprApp.__new__(self.main.hyprwhsprApp)
-        app.playback_suppressor = types.SimpleNamespace(is_active=False, restore=mock.Mock())
-        app._recording_lock = threading.Lock()
-        app._recording_finalizing = threading.Event()
+        app.playback_suppressor = types.SimpleNamespace(is_active=False)
+        app._autostop_stop_silence_monitor = mock.Mock()
+        app._clear_mic_osd_preview_text = mock.Mock()
+        app._stop_audio_level_monitoring = mock.Mock()
         patcher = mock.patch.object(self.main, 'RECORDING_STATUS_FILE', status_path)
         patcher.start()
         self.addCleanup(patcher.stop)
         return app
 
-    def test_end_of_recording_is_published_before_blocking_teardown(self):
+    def test_blocked_hide_releases_capture_client_and_subscriber_slot(self):
         with tempfile.TemporaryDirectory() as tmp:
             status = Path(tmp) / 'recording_status'
             status.write_text('true')
             app = self._app(status)
+            server = self.main.RecordingControlServer(
+                fifo_path=Path(tmp) / 'recording_control',
+                socket_path=Path(tmp) / 'capture.sock',
+                on_command=lambda *args: None,
+                is_recording=lambda: False,
+            )
+            app._recording_control_server = server
+            stop = threading.Event()
+            server._stop_event = stop
+            capture_started = threading.Event()
+            server._write_fifo = lambda command: capture_started.set() or True
+            hide_entered = threading.Event()
+            release_hide = threading.Event()
+            errors = []
+            clients = []
+            workers = []
 
-            hidden = []
-            observed = {}
-            app._hide_mic_osd = mock.Mock(side_effect=lambda: hidden.append(True))
-            app._notify_capture = mock.Mock(side_effect=lambda *args, **kwargs: observed.update(
-                status_still_set=status.exists(),
-                overlay_already_hidden=bool(hidden),
-            ))
-            app._autostop_stop_silence_monitor = mock.Mock()
-            app._clear_mic_osd_preview_text = mock.Mock()
-            app._stop_audio_level_monitoring = mock.Mock()
+            def block_hide():
+                hide_entered.set()
+                release_hide.wait()
 
-            app._cleanup_recording_state()
+            def cleanup():
+                try:
+                    app._cleanup_recording_state()
+                except Exception as exc:
+                    errors.append(exc)
 
-            # First potentially blocking step already sees the recording ended.
-            self.assertFalse(observed['status_still_set'])
-            self.assertTrue(observed['overlay_already_hidden'])
-            self.assertFalse(status.exists())
+            def connect_capture():
+                capture_started.clear()
+                client, connection = socket.socketpair()
+                clients.append(client)
+                client.settimeout(2)
+                worker = threading.Thread(
+                    target=server._handle_capture_connection,
+                    args=(connection, stop),
+                )
+                worker.start()
+                workers.append(worker)
+                client.sendall(b'capture\n')
+                self.assertTrue(capture_started.wait(2), 'capture slot was not acquired')
+                return client, worker
 
-    def test_cleanup_still_restores_playback_and_stops_monitoring(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            status = Path(tmp) / 'recording_status'
-            status.write_text('true')
-            app = self._app(status)
-            app.playback_suppressor = types.SimpleNamespace(is_active=True, restore=mock.Mock())
-            app._hide_mic_osd = mock.Mock()
-            app._notify_capture = mock.Mock()
-            app._autostop_stop_silence_monitor = mock.Mock()
-            app._clear_mic_osd_preview_text = mock.Mock()
-            app._stop_audio_level_monitoring = mock.Mock()
+            app._hide_mic_osd = block_hide
+            try:
+                client, subscriber = connect_capture()
+                cleanup_worker = threading.Thread(target=cleanup)
+                cleanup_worker.start()
+                workers.append(cleanup_worker)
+                self.assertTrue(hide_entered.wait(2), 'cleanup did not reach hide')
 
-            app._cleanup_recording_state()
+                self.assertFalse(status.exists())
+                self.assertEqual(client.recv(1), b'', 'capture client did not receive EOF')
+                subscriber.join(timeout=2)
+                self.assertFalse(subscriber.is_alive())
+                self.assertFalse(server.has_capture_subscriber())
 
-            app._stop_audio_level_monitoring.assert_called_once()
-            app.playback_suppressor.restore.assert_called_once()
+                # A new client can acquire the slot even while hide is stalled.
+                connect_capture()
+                self.assertTrue(server.has_capture_subscriber())
+            finally:
+                release_hide.set()
+                stop.set()
+                for client in clients:
+                    client.close()
+                for worker in workers:
+                    worker.join(timeout=2)
+                self.assertFalse(any(worker.is_alive() for worker in workers))
+            self.assertEqual(errors, [])

--- a/tests/test_recording_cleanup_state.py
+++ b/tests/test_recording_cleanup_state.py
@@ -45,6 +45,7 @@ class RecordingCleanupStateTests(unittest.TestCase):
             server._write_fifo = lambda command: capture_started.set() or True
             hide_entered = threading.Event()
             release_hide = threading.Event()
+            autostop_stopped = threading.Event()
             errors = []
             clients = []
             workers = []
@@ -52,6 +53,8 @@ class RecordingCleanupStateTests(unittest.TestCase):
             def block_hide():
                 hide_entered.set()
                 release_hide.wait()
+
+            app._autostop_stop_silence_monitor.side_effect = autostop_stopped.set
 
             def cleanup():
                 try:
@@ -83,6 +86,10 @@ class RecordingCleanupStateTests(unittest.TestCase):
                 self.assertTrue(hide_entered.wait(2), 'cleanup did not reach hide')
 
                 self.assertFalse(status.exists())
+                self.assertTrue(
+                    autostop_stopped.is_set(),
+                    'old auto-stop monitor was not retired before hide blocked',
+                )
                 self.assertEqual(client.recv(1), b'', 'capture client did not receive EOF')
                 subscriber.join(timeout=2)
                 self.assertFalse(subscriber.is_alive())


### PR DESCRIPTION
Fixes #249.

When a recording ends without the controller clearing `recording_status` — observed after the capture device stopped responding mid-recording — the mic-osd overlay stays mapped on screen indefinitely. Three defects combine; one commit each.

## 1. `_cleanup_recording_state()` published the end of the recording last
`lib/main.py` — it wrote `recording_status=false` after `_notify_capture()`, the autostop teardown, the overlay hide and the level-monitor stop, so a stall in any of those strands the file at `true`. It is now written first, before anything that can block.

## 2. `MicOSDRunner.hide()` tore the feed down before signalling
`lib/mic_osd/runner.py` — `_stop_level_feed()` (unbounded `_level_feed_lock` acquisition, 0.5 s join) and `clear_preview_text()` ran before `SIGUSR2`, so feed bookkeeping could decide whether the overlay left the screen. The signal now goes out first via `_signal_hide()`, with the existing teardown kept in a `finally`.

## 3. `_auto_hide_callback()` trusted that file without bound
`lib/mic_osd/main.py` — it re-armed its 30 s timeout forever while `recording_status` read `true`. The controller rewrites its level feed every tick while capturing but only writes `recording_status` at start/stop, so a feed that stopped advancing proves capture is gone: when the overlay is reading the feed and it has not been rewritten for `FEED_GRACE_SECONDS` (3 s), the overlay hides anyway. Overlays that opened their own `AudioMonitor` (no feed available) keep the current behaviour.

## Tests
Each change carries a regression test that fails on the unpatched code:

- `tests/test_recording_cleanup_state.py` — asserts the status is already cleared and the overlay hidden by the time the first potentially blocking teardown step runs.
- `tests/test_mic_osd_runner.py::test_hide_signals_the_daemon_while_feed_teardown_is_stalled` — a teardown that never returns must not delay `SIGUSR2`.
- `tests/test_mic_osd_stuck_overlay.py` — stale status + dead feed hides; fresh feed during a real recording still re-arms; no feed still believes the status.

`python -m unittest discover -s tests`: 790 tests, with one pre-existing failure in `test_dictation_recovery` that reproduces on unmodified `main` in this environment and is unrelated to this change.

## Verification on the reported machine
Isolated runtime dir, same daemon, released code vs patched, stale `recording_status=true` and a level feed that stops advancing:

```
[pre]  surface mapped after SIGUSR1 -> still mapped after 37s  (log: "Recording active - resetting auto-hide timeout")
[post] surface mapped after SIGUSR1 -> hidden after 37s        (log: "Level feed went stale while recording_status says recording - hiding")
```

Also exercised end-to-end on the live service after applying the patch: `record start` → overlay shown with the live feed, `record cancel` → cleanup, then `recording_status`/`visualizer_state`/`audio_level`/`mic_osd_level_feed` all gone, no overlay surface, no leaked capture streams, `record status` = Idle.

## Not fixed here
The exact call that blocked for ~4 minutes in the original incident is not pinned — the journal shows PortAudio teardown timeouts, but no Python stacks were captured. Every lock acquisition on that path (`_level_feed_lock`, `_autostop_lock`, `_capture_subscriber_lock`) has no deadline, so these fixes deliberately do not depend on knowing which one it was.

Separately: `MicOSDRunner._ensure_daemon()` spawns the daemon with `stdout=DEVNULL`, so nothing it logs (including "resetting auto-hide timeout") reaches the journal — worth surfacing for the next diagnosis.
